### PR TITLE
feat: IndexedDB persistence, shared utils, tests & README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,8 @@ jobs:
       - name: TypeScript check
         run: bunx tsc --noEmit
 
+      - name: Test
+        run: bun run test
+
       - name: Build
         run: bun run build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,92 @@
+# CorvidAgent Chat
+
+Decentralized peer-to-peer messaging client built on [AlgoChat](https://github.com/CorvidLabs/ts-algochat) — encrypted communication over the Algorand blockchain.
+
+## Features
+
+- **End-to-end encrypted messaging** via AES-GCM with PSK (Pre-Shared Key) ratcheting
+- **Algorand-native** — messages are sent as encrypted transaction notes
+- **QR code pairing** — scan a QR code to establish a secure connection
+- **Wallet management** — create or import Algorand wallets with password-encrypted local storage
+- **Message persistence** — chat history stored in IndexedDB, survives page refresh
+- **Offline-first** — works as a static site, no backend required
+- **Markdown rendering** — supports code blocks, bold, italic, links, lists, and more
+
+## Architecture
+
+```
+src/
+  main.ts          # App entry point, view router
+  types.ts         # Core TypeScript interfaces
+  store.ts         # Reactive state management (pub/sub)
+  messaging.ts     # AlgoChat messaging service (send/receive/poll)
+  wallet.ts        # Wallet encryption (AES-GCM + PBKDF2)
+  markdown.ts      # Lightweight markdown-to-HTML renderer
+  qr-scanner.ts    # QR code scanning + PSK URI parsing
+  toast.ts         # Toast notification system
+  utils.ts         # Shared utilities (escapeHtml, base64, etc.)
+  db.ts            # IndexedDB message persistence
+  views/
+    setup.ts       # Wallet creation/import/unlock
+    scan.ts        # QR code scanning for agent pairing
+    chat.ts        # Main chat interface
+    settings.ts    # Wallet & connection management
+```
+
+**Stack:** TypeScript, Vite, vanilla DOM (no framework), Web Crypto API, Algorand SDK, AlgoChat protocol.
+
+## Getting Started
+
+### Prerequisites
+
+- [Bun](https://bun.sh/) (or Node.js 18+)
+
+### Install & Run
+
+```bash
+# Install dependencies
+bun install
+
+# Start dev server
+bun run dev
+
+# Run tests
+bun run test
+
+# Build for production
+bun run build
+```
+
+### Usage
+
+1. **Create or import a wallet** — set a password to encrypt your wallet locally
+2. **Scan the agent's QR code** — or paste the PSK URI manually
+3. **Start chatting** — messages are encrypted and sent as Algorand transactions
+
+## Encryption
+
+- **Wallet storage:** Mnemonic encrypted with AES-256-GCM, key derived via PBKDF2 (600k iterations, SHA-256)
+- **Message encryption:** PSK-based ratcheting with per-message derived keys, NaCl box (X25519 + XSalsa20-Poly1305)
+- **Transport:** Encrypted payloads sent as Algorand payment transaction notes
+
+## Deployment
+
+The app deploys as a static site to GitHub Pages via the `deploy.yml` workflow (triggers on push to `main`).
+
+```bash
+bun run build
+# Output in dist/
+```
+
+## Testing
+
+```bash
+bun run test          # Run once
+bun run test:watch    # Watch mode
+```
+
+Tests cover: utility functions, markdown rendering, and state management.
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -6,13 +6,17 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@types/bun": "latest",
     "@types/node": "^25.2.2",
+    "jsdom": "^28.0.0",
     "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^4.0.18"
   },
   "dependencies": {
     "@corvidlabs/ts-algochat": "^0.3.0",

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,209 @@
+/**
+ * IndexedDB message persistence
+ * Stores chat messages per agent connection, survives page refresh
+ */
+import type { ChatMessage } from './types.ts';
+
+const DB_NAME = 'corvid-chat';
+const DB_VERSION = 1;
+const MESSAGES_STORE = 'messages';
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+/**
+ * Open (or create) the IndexedDB database
+ */
+function openDB(): Promise<IDBDatabase> {
+  if (dbPromise) return dbPromise;
+
+  dbPromise = new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(MESSAGES_STORE)) {
+        const store = db.createObjectStore(MESSAGES_STORE, { keyPath: 'id' });
+        // Index by agent address for per-contact queries
+        store.createIndex('agentAddress', 'agentAddress', { unique: false });
+        // Index by timestamp for sorted retrieval
+        store.createIndex('timestamp', 'timestamp', { unique: false });
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => {
+      dbPromise = null;
+      reject(request.error);
+    };
+  });
+
+  return dbPromise;
+}
+
+/** Stored message with agent address key */
+interface StoredMessage {
+  id: string;
+  agentAddress: string;
+  content: string;
+  direction: 'sent' | 'received';
+  timestamp: number; // epoch ms (IndexedDB can't sort Date objects reliably)
+  status: ChatMessage['status'];
+  txid?: string;
+}
+
+function toStored(msg: ChatMessage, agentAddress: string): StoredMessage {
+  return {
+    id: msg.id,
+    agentAddress,
+    content: msg.content,
+    direction: msg.direction,
+    timestamp: msg.timestamp.getTime(),
+    status: msg.status,
+    txid: msg.txid,
+  };
+}
+
+function fromStored(stored: StoredMessage): ChatMessage {
+  return {
+    id: stored.id,
+    content: stored.content,
+    direction: stored.direction,
+    timestamp: new Date(stored.timestamp),
+    status: stored.status,
+    txid: stored.txid,
+  };
+}
+
+/**
+ * Save a message to IndexedDB
+ */
+export async function saveMessage(
+  msg: ChatMessage,
+  agentAddress: string
+): Promise<void> {
+  try {
+    const db = await openDB();
+    const tx = db.transaction(MESSAGES_STORE, 'readwrite');
+    const store = tx.objectStore(MESSAGES_STORE);
+    store.put(toStored(msg, agentAddress));
+    await new Promise<void>((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } catch (err) {
+    console.error('Failed to save message to IndexedDB:', err);
+  }
+}
+
+/**
+ * Update a message's status (and optionally txid)
+ */
+export async function updateMessageStatus(
+  id: string,
+  status: ChatMessage['status'],
+  txid?: string
+): Promise<void> {
+  try {
+    const db = await openDB();
+    const tx = db.transaction(MESSAGES_STORE, 'readwrite');
+    const store = tx.objectStore(MESSAGES_STORE);
+
+    const existing = await new Promise<StoredMessage | undefined>(
+      (resolve, reject) => {
+        const req = store.get(id);
+        req.onsuccess = () => resolve(req.result as StoredMessage | undefined);
+        req.onerror = () => reject(req.error);
+      }
+    );
+
+    if (existing) {
+      existing.status = status;
+      if (txid) existing.txid = txid;
+      store.put(existing);
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } catch (err) {
+    console.error('Failed to update message status in IndexedDB:', err);
+  }
+}
+
+/**
+ * Load all messages for an agent, sorted by timestamp
+ */
+export async function loadMessages(
+  agentAddress: string
+): Promise<ChatMessage[]> {
+  try {
+    const db = await openDB();
+    const tx = db.transaction(MESSAGES_STORE, 'readonly');
+    const store = tx.objectStore(MESSAGES_STORE);
+    const index = store.index('agentAddress');
+
+    const stored = await new Promise<StoredMessage[]>((resolve, reject) => {
+      const req = index.getAll(agentAddress);
+      req.onsuccess = () => resolve(req.result as StoredMessage[]);
+      req.onerror = () => reject(req.error);
+    });
+
+    return stored
+      .sort((a, b) => a.timestamp - b.timestamp)
+      .map(fromStored);
+  } catch (err) {
+    console.error('Failed to load messages from IndexedDB:', err);
+    return [];
+  }
+}
+
+/**
+ * Delete all messages for an agent
+ */
+export async function clearMessages(agentAddress: string): Promise<void> {
+  try {
+    const db = await openDB();
+    const tx = db.transaction(MESSAGES_STORE, 'readwrite');
+    const store = tx.objectStore(MESSAGES_STORE);
+    const index = store.index('agentAddress');
+
+    const keys = await new Promise<IDBValidKey[]>((resolve, reject) => {
+      const req = index.getAllKeys(agentAddress);
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+
+    for (const key of keys) {
+      store.delete(key);
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } catch (err) {
+    console.error('Failed to clear messages in IndexedDB:', err);
+  }
+}
+
+/**
+ * Delete the entire database (used in "delete all data")
+ */
+export async function deleteDatabase(): Promise<void> {
+  try {
+    // Close existing connection
+    if (dbPromise) {
+      const db = await dbPromise;
+      db.close();
+      dbPromise = null;
+    }
+    await new Promise<void>((resolve, reject) => {
+      const req = indexedDB.deleteDatabase(DB_NAME);
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error);
+    });
+  } catch (err) {
+    console.error('Failed to delete IndexedDB:', err);
+  }
+}

--- a/src/markdown.test.ts
+++ b/src/markdown.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { renderMarkdown } from './markdown.ts';
+
+describe('renderMarkdown', () => {
+  it('escapes HTML entities', () => {
+    const result = renderMarkdown('<script>alert("xss")</script>');
+    expect(result).not.toContain('<script>');
+    expect(result).toContain('&lt;script&gt;');
+  });
+
+  it('renders bold text', () => {
+    const result = renderMarkdown('**bold text**');
+    expect(result).toContain('<strong>bold text</strong>');
+  });
+
+  it('renders italic text', () => {
+    const result = renderMarkdown('*italic text*');
+    expect(result).toContain('<em>italic text</em>');
+  });
+
+  it('renders bold-italic text', () => {
+    const result = renderMarkdown('***bold italic***');
+    expect(result).toContain('<strong><em>bold italic</em></strong>');
+  });
+
+  it('renders inline code', () => {
+    const result = renderMarkdown('Use `console.log()` here');
+    expect(result).toContain('<code>console.log()</code>');
+  });
+
+  it('renders code blocks', () => {
+    const result = renderMarkdown('```js\nconst x = 1;\n```');
+    expect(result).toContain('<pre><code>');
+    expect(result).toContain('const x = 1;');
+  });
+
+  it('renders links with target="_blank"', () => {
+    const result = renderMarkdown('[click me](https://example.com)');
+    expect(result).toContain('href="https://example.com"');
+    expect(result).toContain('target="_blank"');
+    expect(result).toContain('rel="noopener"');
+    expect(result).toContain('>click me</a>');
+  });
+
+  it('renders headers', () => {
+    expect(renderMarkdown('# Title')).toContain('font-size:1.1em');
+    expect(renderMarkdown('## Subtitle')).toContain('font-size:1em');
+    expect(renderMarkdown('### Small')).toContain('font-size:0.95em');
+    expect(renderMarkdown('#### Tiny')).toContain('font-size:0.9em');
+  });
+
+  it('renders blockquotes', () => {
+    const result = renderMarkdown('> quoted text');
+    expect(result).toContain('<blockquote>quoted text</blockquote>');
+  });
+
+  it('renders horizontal rules', () => {
+    expect(renderMarkdown('---')).toContain('<hr>');
+    expect(renderMarkdown('-----')).toContain('<hr>');
+  });
+
+  it('renders unordered lists', () => {
+    const result = renderMarkdown('- item one\n- item two');
+    expect(result).toContain('<ul>');
+    expect(result).toContain('<li>item one</li>');
+    expect(result).toContain('<li>item two</li>');
+  });
+
+  it('renders ordered lists', () => {
+    const result = renderMarkdown('1. first\n2. second');
+    expect(result).toContain('<li>first</li>');
+    expect(result).toContain('<li>second</li>');
+  });
+
+  it('preserves line breaks', () => {
+    const result = renderMarkdown('line one\nline two');
+    expect(result).toContain('<br>');
+  });
+
+  it('handles plain text without modification (except line breaks)', () => {
+    const result = renderMarkdown('Hello World');
+    expect(result).toBe('Hello World');
+  });
+});

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -2,6 +2,7 @@
  * Lightweight markdown renderer
  * Converts markdown to HTML for message display
  */
+import { escapeHtml } from './utils.ts';
 
 export function renderMarkdown(text: string): string {
   // Escape HTML first
@@ -61,12 +62,4 @@ export function renderMarkdown(text: string): string {
   html = html.replace(/<\/blockquote><br>/g, '</blockquote>');
 
   return html;
-}
-
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
 }

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -21,6 +21,7 @@ import {
   decryptPSKMessage,
 } from '@corvidlabs/ts-algochat';
 import type { AgentConnection, ChatMessage } from './types.ts';
+import { base64ToBuffer } from './utils.ts';
 
 const PSK_STATE_KEY = 'corvid-psk-state';
 const LAST_ROUND_KEY = 'corvid-last-round';
@@ -280,7 +281,7 @@ export class MessagingService {
           // Deduplication
           if (this.processedTxids.has(tx.id)) continue;
 
-          const noteBytes = base64ToBytes(tx.note);
+          const noteBytes = base64ToBuffer(tx.note);
 
           // Check PSK protocol
           if (!isPSKMessage(noteBytes)) continue;
@@ -426,17 +427,6 @@ export class MessagingService {
       this.lastRound = parseInt(raw, 10) || 0;
     }
   }
-}
-
-// ── Helpers ──
-
-function base64ToBytes(b64: string): Uint8Array {
-  const binary = atob(b64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
 }
 
 // Singleton

--- a/src/qr-scanner.ts
+++ b/src/qr-scanner.ts
@@ -5,6 +5,7 @@
 import { Html5Qrcode } from 'html5-qrcode';
 import { parsePSKExchangeURI } from '@corvidlabs/ts-algochat';
 import type { AgentConnection } from './types.ts';
+import { bufferToBase64, base64ToBuffer } from './utils.ts';
 
 const AGENT_STORAGE_KEY = 'corvid-agent-connection';
 
@@ -157,23 +158,4 @@ export function loadConnection(): AgentConnection | null {
  */
 export function clearConnection(): void {
   localStorage.removeItem(AGENT_STORAGE_KEY);
-}
-
-// ── Helpers ──
-
-function bufferToBase64(buf: Uint8Array): string {
-  let binary = '';
-  for (let i = 0; i < buf.length; i++) {
-    binary += String.fromCharCode(buf[i]!);
-  }
-  return btoa(binary);
-}
-
-function base64ToBuffer(b64: string): Uint8Array {
-  const binary = atob(b64);
-  const buf = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    buf[i] = binary.charCodeAt(i);
-  }
-  return buf;
 }

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// We need to test the Store class, but it's exported as a singleton.
+// We'll import and test the singleton, resetting between tests.
+// Since we can't easily create new instances, we'll test the exported store.
+
+// Store is a singleton, so we need to work around that.
+// Let's import it and use lockWallet to reset between tests.
+import { store } from './store.ts';
+import type { ChatMessage, AgentConnection } from './types.ts';
+
+describe('Store', () => {
+  beforeEach(() => {
+    // Reset to initial state
+    store.lockWallet();
+    store.clearAgent();
+  });
+
+  describe('view management', () => {
+    it('starts at setup view after reset', () => {
+      expect(store.getState().view).toBe('setup');
+    });
+
+    it('changes view', () => {
+      store.setView('chat');
+      expect(store.getState().view).toBe('chat');
+    });
+
+    it('notifies subscribers on view change', () => {
+      let called = false;
+      const unsub = store.subscribe(() => {
+        called = true;
+      });
+      store.setView('scan');
+      expect(called).toBe(true);
+      unsub();
+    });
+  });
+
+  describe('wallet management', () => {
+    it('sets wallet address and unlocked state', () => {
+      store.setWallet('TESTADDR123');
+      const state = store.getState();
+      expect(state.wallet.address).toBe('TESTADDR123');
+      expect(state.wallet.unlocked).toBe(true);
+    });
+
+    it('sets balance', () => {
+      store.setBalance(5_000_000);
+      expect(store.getState().wallet.balance).toBe(5_000_000);
+    });
+
+    it('locks wallet and resets state', () => {
+      store.setWallet('ADDR');
+      store.setBalance(1000);
+      store.lockWallet();
+
+      const state = store.getState();
+      expect(state.wallet.address).toBeNull();
+      expect(state.wallet.unlocked).toBe(false);
+      expect(state.wallet.balance).toBe(0);
+      expect(state.view).toBe('setup');
+    });
+  });
+
+  describe('agent management', () => {
+    const mockConnection: AgentConnection = {
+      address: 'AGENTADDR',
+      psk: new Uint8Array([1, 2, 3]),
+      label: 'Test Agent',
+      network: 'testnet',
+      addedAt: Date.now(),
+    };
+
+    it('sets agent connection', () => {
+      store.setAgentConnection(mockConnection);
+      const state = store.getState();
+      expect(state.agent.connection).toEqual(mockConnection);
+      expect(state.agent.online).toBe(false);
+    });
+
+    it('sets agent online status', () => {
+      store.setAgentOnline(true);
+      expect(store.getState().agent.online).toBe(true);
+    });
+
+    it('updates lastSeen when going online', () => {
+      store.setAgentOnline(true);
+      expect(store.getState().agent.lastSeen).not.toBeNull();
+    });
+
+    it('clears agent and messages', () => {
+      store.setAgentConnection(mockConnection);
+      store.addMessage({
+        id: 'msg1',
+        content: 'test',
+        direction: 'sent',
+        timestamp: new Date(),
+        status: 'confirmed',
+      });
+
+      store.clearAgent();
+      const state = store.getState();
+      expect(state.agent.connection).toBeNull();
+      expect(state.chat.messages).toHaveLength(0);
+    });
+  });
+
+  describe('message management', () => {
+    const createMsg = (id: string, ts: number): ChatMessage => ({
+      id,
+      content: `Message ${id}`,
+      direction: 'sent',
+      timestamp: new Date(ts),
+      status: 'confirmed',
+    });
+
+    it('adds messages', () => {
+      store.addMessage(createMsg('1', 1000));
+      expect(store.getState().chat.messages).toHaveLength(1);
+    });
+
+    it('deduplicates by id', () => {
+      const msg = createMsg('1', 1000);
+      store.addMessage(msg);
+      store.addMessage(msg);
+      expect(store.getState().chat.messages).toHaveLength(1);
+    });
+
+    it('sorts messages by timestamp', () => {
+      store.addMessage(createMsg('b', 2000));
+      store.addMessage(createMsg('a', 1000));
+      store.addMessage(createMsg('c', 3000));
+
+      const messages = store.getState().chat.messages;
+      expect(messages[0]!.id).toBe('a');
+      expect(messages[1]!.id).toBe('b');
+      expect(messages[2]!.id).toBe('c');
+    });
+
+    it('updates message status', () => {
+      store.addMessage(createMsg('1', 1000));
+      store.updateMessageStatus('1', 'failed');
+      expect(store.getState().chat.messages[0]!.status).toBe('failed');
+    });
+
+    it('updates message txid', () => {
+      store.addMessage(createMsg('1', 1000));
+      store.updateMessageStatus('1', 'confirmed', 'TX123');
+      expect(store.getState().chat.messages[0]!.txid).toBe('TX123');
+    });
+
+    it('clears messages', () => {
+      store.addMessage(createMsg('1', 1000));
+      store.addMessage(createMsg('2', 2000));
+      store.clearMessages();
+      expect(store.getState().chat.messages).toHaveLength(0);
+    });
+  });
+
+  describe('chat flags', () => {
+    it('sets polling flag', () => {
+      store.setPolling(true);
+      expect(store.getState().chat.polling).toBe(true);
+      store.setPolling(false);
+      expect(store.getState().chat.polling).toBe(false);
+    });
+
+    it('sets sending flag', () => {
+      store.setSending(true);
+      expect(store.getState().chat.sending).toBe(true);
+      store.setSending(false);
+      expect(store.getState().chat.sending).toBe(false);
+    });
+  });
+
+  describe('subscriptions', () => {
+    it('can unsubscribe', () => {
+      let count = 0;
+      const unsub = store.subscribe(() => count++);
+      store.setView('chat');
+      expect(count).toBe(1);
+
+      unsub();
+      store.setView('settings');
+      expect(count).toBe(1);
+    });
+
+    it('supports multiple subscribers', () => {
+      let count1 = 0;
+      let count2 = 0;
+      const unsub1 = store.subscribe(() => count1++);
+      const unsub2 = store.subscribe(() => count2++);
+
+      store.setView('chat');
+      expect(count1).toBe(1);
+      expect(count2).toBe(1);
+
+      unsub1();
+      unsub2();
+    });
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export interface ChatMessage {
 }
 
 export interface AppState {
-  view: 'setup' | 'scan' | 'chat' | 'settings' | 'wallet';
+  view: 'setup' | 'scan' | 'chat' | 'settings';
   wallet: WalletState;
   agent: AgentState;
   chat: ChatState;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { escapeHtml, bufferToBase64, base64ToBuffer, shortenAddress } from './utils.ts';
+
+describe('escapeHtml', () => {
+  it('escapes ampersands', () => {
+    expect(escapeHtml('foo & bar')).toBe('foo &amp; bar');
+  });
+
+  it('escapes angle brackets', () => {
+    expect(escapeHtml('<script>alert("xss")</script>')).toBe(
+      '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;'
+    );
+  });
+
+  it('escapes quotes', () => {
+    expect(escapeHtml('"hello"')).toBe('&quot;hello&quot;');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(escapeHtml('')).toBe('');
+  });
+
+  it('leaves safe text unchanged', () => {
+    expect(escapeHtml('Hello World 123')).toBe('Hello World 123');
+  });
+});
+
+describe('bufferToBase64 / base64ToBuffer', () => {
+  it('round-trips simple data', () => {
+    const original = new Uint8Array([1, 2, 3, 4, 5]);
+    const b64 = bufferToBase64(original);
+    const restored = base64ToBuffer(b64);
+    expect(restored).toEqual(original);
+  });
+
+  it('round-trips empty array', () => {
+    const original = new Uint8Array([]);
+    const b64 = bufferToBase64(original);
+    const restored = base64ToBuffer(b64);
+    expect(restored).toEqual(original);
+  });
+
+  it('round-trips binary data (0-255)', () => {
+    const original = new Uint8Array(256);
+    for (let i = 0; i < 256; i++) original[i] = i;
+    const b64 = bufferToBase64(original);
+    const restored = base64ToBuffer(b64);
+    expect(restored).toEqual(original);
+  });
+
+  it('produces valid base64', () => {
+    const data = new Uint8Array([72, 101, 108, 108, 111]); // "Hello"
+    const b64 = bufferToBase64(data);
+    expect(b64).toBe(btoa('Hello'));
+  });
+});
+
+describe('shortenAddress', () => {
+  const addr = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ2345';
+
+  it('shortens with default params', () => {
+    const result = shortenAddress(addr);
+    expect(result).toBe('ABCDEF...2345');
+    expect(result.length).toBeLessThan(addr.length);
+  });
+
+  it('shortens with custom prefix/suffix', () => {
+    const result = shortenAddress(addr, 4, 6);
+    expect(result).toBe('ABCD...YZ2345');
+  });
+
+  it('returns full address if short enough', () => {
+    const short = 'ABCDE';
+    expect(shortenAddress(short, 3, 3)).toBe('ABCDE');
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared utility functions
+ */
+
+/**
+ * Escape HTML entities to prevent XSS
+ */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Convert a Uint8Array to a base64 string
+ */
+export function bufferToBase64(buf: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < buf.length; i++) {
+    binary += String.fromCharCode(buf[i]!);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Convert a base64 string to a Uint8Array
+ */
+export function base64ToBuffer(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const buf = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    buf[i] = binary.charCodeAt(i);
+  }
+  return buf;
+}
+
+/**
+ * Shorten an Algorand address for display
+ */
+export function shortenAddress(
+  address: string,
+  prefixLen = 6,
+  suffixLen = 4
+): string {
+  if (address.length <= prefixLen + suffixLen + 3) return address;
+  return `${address.slice(0, prefixLen)}...${address.slice(-suffixLen)}`;
+}

--- a/src/views/chat.ts
+++ b/src/views/chat.ts
@@ -7,6 +7,8 @@ import { getAccount } from '../wallet.ts';
 import { renderMarkdown } from '../markdown.ts';
 import { showToast } from '../toast.ts';
 import type { ChatMessage } from '../types.ts';
+import { escapeHtml, shortenAddress } from '../utils.ts';
+import { saveMessage, updateMessageStatus as dbUpdateStatus, loadMessages } from '../db.ts';
 
 let outputEl: HTMLElement | null = null;
 let inputEl: HTMLTextAreaElement | null = null;
@@ -18,12 +20,8 @@ export function renderChat(): string {
   const wallet = state.wallet;
 
   const agentLabel = agent?.label ?? 'Unknown Agent';
-  const agentAddr = agent?.address
-    ? `${agent.address.slice(0, 6)}...${agent.address.slice(-4)}`
-    : '';
-  const walletAddr = wallet.address
-    ? `${wallet.address.slice(0, 4)}...${wallet.address.slice(-4)}`
-    : '';
+  const agentAddr = agent?.address ? shortenAddress(agent.address) : '';
+  const walletAddr = wallet.address ? shortenAddress(wallet.address, 4, 4) : '';
   const network = agent?.network ?? 'mainnet';
 
   return `
@@ -85,10 +83,20 @@ export function bindChatEvents(): void {
 
   messaging.initialize(account, connection);
 
+  // Load persisted message history from IndexedDB
+  loadMessages(connection.address).then((history) => {
+    for (const msg of history) {
+      store.addMessage(msg);
+      appendMessage(msg);
+    }
+  });
+
   // Subscribe to incoming messages
   unsubMessages = messaging.onMessage((msg: ChatMessage) => {
     store.addMessage(msg);
     appendMessage(msg);
+    // Persist to IndexedDB
+    saveMessage(msg, connection.address);
   });
 
   // Start polling
@@ -139,6 +147,8 @@ export function bindChatEvents(): void {
 
     store.addMessage(outMsg);
     appendMessage(outMsg);
+    // Persist optimistic message
+    saveMessage(outMsg, connection.address);
 
     inputEl.value = '';
     inputEl.style.height = 'auto';
@@ -151,12 +161,15 @@ export function bindChatEvents(): void {
       const txid = await messaging.sendMessage(content);
       store.updateMessageStatus(tempId, 'confirmed', txid);
       updateMessageEl(tempId, 'confirmed');
+      // Update persisted status
+      dbUpdateStatus(tempId, 'confirmed', txid);
 
       // Show waiting indicator
       showThinking();
     } catch (err) {
       store.updateMessageStatus(tempId, 'failed');
       updateMessageEl(tempId, 'failed');
+      dbUpdateStatus(tempId, 'failed');
       showToast(
         `Send failed: ${err instanceof Error ? err.message : 'unknown error'}`,
         'error'
@@ -307,11 +320,4 @@ export function cleanupChat(): void {
 
   outputEl = null;
   inputEl = null;
-}
-
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
 }

--- a/src/views/settings.ts
+++ b/src/views/settings.ts
@@ -6,6 +6,8 @@ import { getAccount, exportMnemonic, deleteWallet, lockWallet } from '../wallet.
 import { clearConnection, loadConnection } from '../qr-scanner.ts';
 import { messaging } from '../messaging.ts';
 import { showToast } from '../toast.ts';
+import { escapeHtml } from '../utils.ts';
+import { deleteDatabase } from '../db.ts';
 
 export function renderSettings(): string {
   const state = store.getState();
@@ -233,7 +235,7 @@ export function bindSettingsEvents(): void {
   // Delete all data
   document
     .getElementById('btn-delete-all')
-    ?.addEventListener('click', () => {
+    ?.addEventListener('click', async () => {
       if (
         confirm(
           'This will permanently delete your wallet and all data. This cannot be undone. Continue?'
@@ -242,15 +244,10 @@ export function bindSettingsEvents(): void {
         messaging.destroy();
         clearConnection();
         deleteWallet();
+        await deleteDatabase();
         localStorage.clear();
         store.lockWallet();
         showToast('All data deleted', 'info');
       }
     });
-}
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
 }

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -9,6 +9,7 @@ import {
   type ChatAccount,
 } from '@corvidlabs/ts-algochat';
 import type { StoredWallet } from './types.ts';
+import { bufferToBase64, base64ToBuffer } from './utils.ts';
 
 const STORAGE_KEY = 'corvid-wallet';
 const PBKDF2_ITERATIONS = 600_000;
@@ -178,21 +179,4 @@ async function decryptMnemonic(
   } catch {
     throw new Error('Invalid password');
   }
-}
-
-function bufferToBase64(buf: Uint8Array): string {
-  let binary = '';
-  for (let i = 0; i < buf.length; i++) {
-    binary += String.fromCharCode(buf[i]!);
-  }
-  return btoa(binary);
-}
-
-function base64ToBuffer(b64: string): Uint8Array {
-  const binary = atob(b64);
-  const buf = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    buf[i] = binary.charCodeAt(i);
-  }
-  return buf;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vite';
+import { configDefaults } from 'vitest/config';
 
 export default defineConfig({
   base: '/corvid-agent-chat/',
@@ -21,5 +22,10 @@ export default defineConfig({
   server: {
     port: 5173,
     open: true,
+  },
+  test: {
+    environment: 'jsdom',
+    exclude: [...configDefaults.exclude],
+    include: ['src/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
## Summary
- **IndexedDB message persistence** — chat history now survives page refresh, stored per-agent in IndexedDB with automatic save/load
- **Shared utilities** — extracted `escapeHtml`, `bufferToBase64`/`base64ToBuffer`, `shortenAddress` from 5 files into `utils.ts`, eliminating copy-paste duplication
- **46 unit tests** — added Vitest with tests for utilities, markdown renderer, and state store
- **README** — architecture overview, setup instructions, encryption details, and deployment guide
- **Cleanup** — removed dead `wallet` view from type union, added test step to CI

## Test plan
- [x] `tsc --noEmit` passes
- [x] `vitest run` — 46/46 tests pass
- [x] `vite build` — production build succeeds
- [ ] CI workflow runs (typecheck + test + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)