### PR TITLE
fix: cache compiled RegExp and debounce search input

### DIFF
--- a/src/views/chat.ts
+++ b/src/views/chat.ts
@@ -18,6 +18,8 @@ const STATUS_CHECK_INTERVAL_MS = 30_000;
 const INPUT_MAX_HEIGHT_PX = 200;
 /** Duration to show copy confirmation before reverting (ms) */
 const COPY_FEEDBACK_MS = 1_500;
+/** Debounce delay for search input (ms) */
+const SEARCH_DEBOUNCE_MS = 150;
 
 let outputEl: HTMLElement | null = null;
 let inputEl: HTMLTextAreaElement | null = null;
@@ -30,6 +32,7 @@ let searchOpen = false;
 let searchQuery = '';
 let searchMatches: HTMLElement[] = [];
 let searchCurrentIdx = -1;
+let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 /* ── Pending attachment state ── */
 let pendingAttachment: Attachment | null = null;
@@ -436,6 +439,10 @@ export function bindChatEvents(): void {
     searchQuery = '';
     searchMatches = [];
     searchCurrentIdx = -1;
+    if (searchDebounceTimer) {
+      clearTimeout(searchDebounceTimer);
+      searchDebounceTimer = null;
+    }
     if (searchCount) searchCount.textContent = '';
   }
 
@@ -521,15 +528,15 @@ export function bindChatEvents(): void {
       return;
     }
 
-    // Escape regex special chars
+    // Escape regex special chars and compile once
     const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const regex = new RegExp(escaped, 'gi');
+    const matchRegex = new RegExp(escaped, 'i');
 
     // Search through the message store for matching content
     const messages = store.getState().chat.messages;
     const matchingIds = new Set<string>();
     for (const msg of messages) {
-      if (msg.content.match(new RegExp(escaped, 'i'))) {
+      if (matchRegex.test(msg.content)) {
         matchingIds.add(msg.id);
       }
     }
@@ -600,7 +607,10 @@ export function bindChatEvents(): void {
 
   searchInput?.addEventListener('input', () => {
     searchQuery = searchInput.value;
-    executeSearch(searchQuery);
+    if (searchDebounceTimer) clearTimeout(searchDebounceTimer);
+    searchDebounceTimer = setTimeout(() => {
+      executeSearch(searchQuery);
+    }, SEARCH_DEBOUNCE_MS);
   });
 
   searchInput?.addEventListener('keydown', (e) => {


### PR DESCRIPTION
## Summary
- Compiles `RegExp` once per search execution instead of creating new instances per-message and per-element (was 3× redundant compilation)
- Uses `.test()` instead of `.match()` for content filtering since captures aren't needed
- Adds 150ms debounce on the search input to avoid re-running the full search on every keystroke
- Cleans up debounce timer on search close

Closes #12

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 128 existing unit tests pass
- [ ] Manual test: type quickly in search bar, confirm results appear after brief debounce
- [ ] Manual test: search highlighting still works correctly
- [ ] Manual test: prev/next navigation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)