### PR TITLE
test: add unit tests for view modules

### DIFF
--- a/src/views/chat.test.ts
+++ b/src/views/chat.test.ts
@@ -1,0 +1,644 @@
+/**
+ * Unit tests for the chat view — rendering, send message, search, and interactions
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { AgentConnection, ChatMessage } from '../types.ts';
+
+// jsdom does not implement scrollIntoView — stub it globally
+Element.prototype.scrollIntoView = vi.fn();
+
+// ── Hoisted mocks ──
+
+const {
+  fakeConnection,
+  defaultStoreState,
+  mockStore,
+  mockMessaging,
+  mockWallet,
+  mockToast,
+  mockDb,
+  mockDeviceName,
+} = vi.hoisted(() => {
+  const fakeConnection: AgentConnection = {
+    address: 'AGENTADDRESS1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEF',
+    psk: new Uint8Array(32),
+    label: 'TestAgent',
+    network: 'testnet',
+    addedAt: Date.now(),
+  };
+
+  const defaultStoreState = (): {
+    view: string;
+    wallet: { address: string | null; unlocked: boolean; balance: number };
+    agent: { connection: AgentConnection | null; online: boolean; lastSeen: number | null };
+    chat: { messages: ChatMessage[]; polling: boolean; sending: boolean };
+  } => ({
+    view: 'chat',
+    wallet: { address: 'WALLETADDR1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ2345678ABCDEF', unlocked: true, balance: 5_000_000 },
+    agent: { connection: fakeConnection, online: true, lastSeen: Date.now() },
+    chat: { messages: [], polling: false, sending: false },
+  });
+
+  return {
+    fakeConnection,
+    defaultStoreState,
+    mockStore: {
+      getState: vi.fn(defaultStoreState),
+      setView: vi.fn(),
+      setWallet: vi.fn(),
+      setAgentConnection: vi.fn(),
+      setAgentOnline: vi.fn(),
+      setBalance: vi.fn(),
+      addMessage: vi.fn(),
+      updateMessageStatus: vi.fn(),
+      setPolling: vi.fn(),
+      setSending: vi.fn(),
+    },
+    mockMessaging: {
+      initialize: vi.fn(),
+      onMessage: vi.fn((_cb?: unknown) => vi.fn()),
+      onPollError: vi.fn((_cb?: unknown) => vi.fn()),
+      startPolling: vi.fn(),
+      stopPolling: vi.fn(),
+      checkAgentOnline: vi.fn().mockResolvedValue(true),
+      getBalance: vi.fn().mockResolvedValue(5_000_000),
+      sendMessage: vi.fn().mockResolvedValue('TXID123'),
+      destroy: vi.fn(),
+      consecutiveErrors: 0,
+    },
+    mockWallet: {
+      getAccount: vi.fn((): unknown => ({
+        address: 'WALLETADDR',
+        account: { sk: new Uint8Array(64) },
+        encryptionKeys: { publicKey: new Uint8Array(32), privateKey: new Uint8Array(32) },
+      })),
+    },
+    mockToast: { showToast: vi.fn() },
+    mockDb: {
+      saveMessage: vi.fn(),
+      updateMessageStatus: vi.fn(),
+      loadMessages: vi.fn().mockResolvedValue([]),
+    },
+    mockDeviceName: {
+      getDeviceName: vi.fn((): string | null => null),
+    },
+  };
+});
+
+vi.mock('../store.ts', () => ({ store: mockStore }));
+vi.mock('../messaging.ts', () => ({ messaging: mockMessaging }));
+vi.mock('../wallet.ts', () => mockWallet);
+vi.mock('../toast.ts', () => mockToast);
+vi.mock('../db.ts', () => mockDb);
+vi.mock('../device-name.ts', () => mockDeviceName);
+vi.mock('../markdown.ts', () => ({
+  renderMarkdown: vi.fn((text: string) => text),
+}));
+vi.mock('../utils.ts', () => ({
+  escapeHtml: (s: string) => s,
+  shortenAddress: (s: string, a = 6, b = 4) => `${s.slice(0, a)}...${s.slice(-b)}`,
+  formatTime: () => '12:00',
+}));
+vi.mock('../file-handler.ts', () => ({
+  processFile: vi.fn(),
+  createImagePreview: vi.fn(() => document.createElement('div')),
+  createFileDownload: vi.fn(() => document.createElement('div')),
+  formatFileSize: vi.fn((n: number) => `${n} B`),
+  isAcceptedType: vi.fn(() => true),
+}));
+
+import { renderChat, bindChatEvents, cleanupChat } from './chat.ts';
+
+// ── Helpers ──
+
+function renderIntoDOM(html: string): void {
+  document.body.innerHTML = `<div id="app">${html}</div>`;
+}
+
+let messageCallback: ((msg: ChatMessage) => void) | null = null;
+
+function setupChat(): void {
+  mockMessaging.onMessage.mockImplementation((cb?: unknown) => {
+    messageCallback = cb as (msg: ChatMessage) => void;
+    return vi.fn();
+  });
+  renderIntoDOM(renderChat());
+  bindChatEvents();
+}
+
+// ── Tests ──
+
+describe('chat view', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    document.body.innerHTML = '';
+    messageCallback = null;
+    mockStore.getState.mockImplementation(defaultStoreState);
+  });
+
+  afterEach(() => {
+    cleanupChat();
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  // ── renderChat ──
+
+  describe('renderChat', () => {
+    it('renders the header with agent label and network badge', () => {
+      const html = renderChat();
+      expect(html).toContain('TestAgent');
+      expect(html).toContain('network-badge--testnet');
+      expect(html).toContain('testnet');
+    });
+
+    it('renders chat input and send button', () => {
+      const html = renderChat();
+      expect(html).toContain('id="chat-input"');
+      expect(html).toContain('id="btn-send"');
+    });
+
+    it('renders search bar hidden by default', () => {
+      renderIntoDOM(renderChat());
+      const searchBar = document.getElementById('search-bar');
+      expect(searchBar).toBeTruthy();
+      expect(searchBar!.style.display).toBe('none');
+    });
+
+    it('renders connection bar', () => {
+      const html = renderChat();
+      expect(html).toContain('id="connection-bar"');
+      expect(html).toContain('Connecting...');
+    });
+
+    it('renders wallet badge with shortened address', () => {
+      const html = renderChat();
+      expect(html).toContain('id="wallet-badge"');
+      // shortenAddress called with (addr, 4, 4) — mock uses provided args
+      expect(html).toContain('WALL...CDEF');
+    });
+
+    it('renders settings and search buttons', () => {
+      const html = renderChat();
+      expect(html).toContain('id="btn-settings"');
+      expect(html).toContain('id="btn-search"');
+    });
+
+    it('renders attachment UI elements', () => {
+      const html = renderChat();
+      expect(html).toContain('id="btn-attach"');
+      expect(html).toContain('id="file-input"');
+      expect(html).toContain('id="attachment-preview"');
+    });
+  });
+
+  // ── initialization ──
+
+  describe('initialization', () => {
+    it('redirects to setup when account is missing', () => {
+      mockWallet.getAccount.mockReturnValueOnce(null);
+      renderIntoDOM(renderChat());
+      bindChatEvents();
+
+      expect(mockToast.showToast).toHaveBeenCalledWith(
+        'Wallet or agent not configured',
+        'error'
+      );
+      expect(mockStore.setView).toHaveBeenCalledWith('setup');
+    });
+
+    it('redirects to setup when agent connection is missing', () => {
+      mockStore.getState.mockReturnValue({
+        ...defaultStoreState(),
+        agent: { connection: null, online: false, lastSeen: null },
+      });
+      renderIntoDOM(renderChat());
+      bindChatEvents();
+
+      expect(mockToast.showToast).toHaveBeenCalledWith(
+        'Wallet or agent not configured',
+        'error'
+      );
+      expect(mockStore.setView).toHaveBeenCalledWith('setup');
+    });
+
+    it('initializes messaging service with account and connection', () => {
+      setupChat();
+
+      expect(mockMessaging.initialize).toHaveBeenCalledWith(
+        expect.any(Object),
+        fakeConnection
+      );
+    });
+
+    it('starts polling and subscribes to messages', () => {
+      setupChat();
+
+      expect(mockMessaging.startPolling).toHaveBeenCalled();
+      expect(mockStore.setPolling).toHaveBeenCalledWith(true);
+      expect(mockMessaging.onMessage).toHaveBeenCalled();
+    });
+  });
+
+  // ── send message ──
+
+  describe('send message flow', () => {
+    it('send button is disabled by default', () => {
+      setupChat();
+      const btn = document.getElementById('btn-send')!;
+      expect(btn.hasAttribute('disabled')).toBe(true);
+    });
+
+    it('enables send button when text is entered', () => {
+      setupChat();
+      const input = document.getElementById('chat-input') as HTMLTextAreaElement;
+      const btn = document.getElementById('btn-send')!;
+
+      input.value = 'Hello';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+
+      expect(btn.hasAttribute('disabled')).toBe(false);
+    });
+
+    it('disables send button when text is cleared', () => {
+      setupChat();
+      const input = document.getElementById('chat-input') as HTMLTextAreaElement;
+      const btn = document.getElementById('btn-send')!;
+
+      input.value = 'Hello';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      expect(btn.hasAttribute('disabled')).toBe(false);
+
+      input.value = '';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      expect(btn.hasAttribute('disabled')).toBe(true);
+    });
+
+    it('sends message on button click', async () => {
+      setupChat();
+      const input = document.getElementById('chat-input') as HTMLTextAreaElement;
+      const btn = document.getElementById('btn-send')!;
+
+      input.value = 'Hello agent';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      btn.click();
+
+      await vi.waitFor(() => {
+        expect(mockMessaging.sendMessage).toHaveBeenCalledWith('Hello agent', undefined);
+        expect(mockStore.addMessage).toHaveBeenCalled();
+        expect(mockStore.setSending).toHaveBeenCalledWith(true);
+      });
+    });
+
+    it('sends message on Enter key', async () => {
+      setupChat();
+      const input = document.getElementById('chat-input') as HTMLTextAreaElement;
+
+      input.value = 'Enter message';
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+      );
+
+      await vi.waitFor(() => {
+        expect(mockMessaging.sendMessage).toHaveBeenCalledWith('Enter message', undefined);
+      });
+    });
+
+    it('does not send on Shift+Enter (allows newline)', () => {
+      setupChat();
+      const input = document.getElementById('chat-input') as HTMLTextAreaElement;
+
+      input.value = 'Multi-line';
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          shiftKey: true,
+          bubbles: true,
+        })
+      );
+
+      expect(mockMessaging.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('does not send when input is empty', () => {
+      setupChat();
+      const input = document.getElementById('chat-input') as HTMLTextAreaElement;
+      const btn = document.getElementById('btn-send')!;
+
+      input.value = '';
+      btn.click();
+
+      expect(mockMessaging.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('clears input after sending', async () => {
+      setupChat();
+      const input = document.getElementById('chat-input') as HTMLTextAreaElement;
+
+      input.value = 'Will be cleared';
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+      );
+
+      await vi.waitFor(() => {
+        expect(input.value).toBe('');
+      });
+    });
+
+    it('shows error toast on send failure', async () => {
+      mockMessaging.sendMessage.mockRejectedValueOnce(
+        new Error('Insufficient funds')
+      );
+
+      setupChat();
+      const input = document.getElementById('chat-input') as HTMLTextAreaElement;
+
+      input.value = 'Will fail';
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+      );
+
+      await vi.waitFor(() => {
+        expect(mockToast.showToast).toHaveBeenCalledWith(
+          'Send failed: Insufficient funds',
+          'error'
+        );
+      });
+    });
+
+    it('adds optimistic message to the DOM on send', async () => {
+      setupChat();
+      const input = document.getElementById('chat-input') as HTMLTextAreaElement;
+
+      input.value = 'Optimistic message';
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+      );
+
+      await vi.waitFor(() => {
+        const output = document.getElementById('chat-output')!;
+        expect(output.querySelectorAll('.msg--outbound').length).toBe(1);
+      });
+    });
+  });
+
+  // ── search feature ──
+
+  describe('search feature', () => {
+    it('opens search bar on search button click', () => {
+      setupChat();
+      const btn = document.getElementById('btn-search')!;
+      const searchBar = document.getElementById('search-bar')!;
+
+      btn.click();
+
+      expect(searchBar.style.display).toBe('');
+    });
+
+    it('closes search bar on second click (toggle)', () => {
+      setupChat();
+      const btn = document.getElementById('btn-search')!;
+      const searchBar = document.getElementById('search-bar')!;
+
+      btn.click(); // open
+      btn.click(); // close
+
+      expect(searchBar.style.display).toBe('none');
+    });
+
+    it('closes search bar via close button', () => {
+      setupChat();
+      document.getElementById('btn-search')!.click();
+
+      document.getElementById('search-close')!.click();
+
+      expect(document.getElementById('search-bar')!.style.display).toBe('none');
+    });
+
+    it('closes search on Escape key in search input', () => {
+      setupChat();
+      document.getElementById('btn-search')!.click();
+
+      const searchInput = document.getElementById('search-input') as HTMLInputElement;
+      searchInput.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+      );
+
+      expect(document.getElementById('search-bar')!.style.display).toBe('none');
+    });
+
+    it('opens search on Ctrl+F', () => {
+      setupChat();
+      const searchBar = document.getElementById('search-bar')!;
+
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'f', ctrlKey: true, bubbles: true })
+      );
+
+      expect(searchBar.style.display).toBe('');
+    });
+
+    it('shows "No matches" when search has no results', () => {
+      setupChat();
+
+      document.getElementById('btn-search')!.click();
+      const searchInput = document.getElementById('search-input') as HTMLInputElement;
+      searchInput.value = 'nonexistent';
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+      vi.advanceTimersByTime(200);
+
+      const searchCount = document.getElementById('search-count')!;
+      expect(searchCount.textContent).toBe('No matches');
+    });
+
+    it('highlights matching messages in search results', () => {
+      const msg: ChatMessage = {
+        id: 'msg-1',
+        content: 'Hello from agent',
+        direction: 'received',
+        timestamp: new Date(),
+        status: 'confirmed',
+      };
+      mockStore.getState.mockReturnValue({
+        ...defaultStoreState(),
+        chat: { messages: [msg], polling: false, sending: false },
+      });
+      setupChat();
+
+      // Add a message element that matches the store's message
+      const output = document.getElementById('chat-output')!;
+      const msgEl = document.createElement('div');
+      msgEl.className = 'msg msg--inbound';
+      msgEl.id = 'msg-msg-1';
+      msgEl.innerHTML = '<span class="msg__text">Hello from agent</span>';
+      output.appendChild(msgEl);
+
+      document.getElementById('btn-search')!.click();
+      const searchInput = document.getElementById('search-input') as HTMLInputElement;
+      searchInput.value = 'Hello';
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+      vi.advanceTimersByTime(200);
+
+      const searchCount = document.getElementById('search-count')!;
+      expect(searchCount.textContent).toBe('1 of 1 match');
+      expect(msgEl.classList.contains('msg--search-match')).toBe(true);
+      expect(msgEl.classList.contains('msg--search-active')).toBe(true);
+    });
+
+    it('shows correct count with multiple matches', () => {
+      const msgs: ChatMessage[] = [
+        { id: 'msg-1', content: 'Hello world', direction: 'received', timestamp: new Date(), status: 'confirmed' },
+        { id: 'msg-2', content: 'Hello again', direction: 'sent', timestamp: new Date(), status: 'confirmed' },
+        { id: 'msg-3', content: 'Goodbye', direction: 'received', timestamp: new Date(), status: 'confirmed' },
+      ];
+      mockStore.getState.mockReturnValue({
+        ...defaultStoreState(),
+        chat: { messages: msgs, polling: false, sending: false },
+      });
+      setupChat();
+
+      const output = document.getElementById('chat-output')!;
+      for (const msg of msgs) {
+        const el = document.createElement('div');
+        el.className = 'msg';
+        el.id = `msg-${msg.id}`;
+        el.innerHTML = `<span class="msg__text">${msg.content}</span>`;
+        output.appendChild(el);
+      }
+
+      document.getElementById('btn-search')!.click();
+      const searchInput = document.getElementById('search-input') as HTMLInputElement;
+      searchInput.value = 'Hello';
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+      vi.advanceTimersByTime(200);
+
+      const searchCount = document.getElementById('search-count')!;
+      expect(searchCount.textContent).toBe('1 of 2 matches');
+    });
+
+    it('navigates between matches with Enter key', () => {
+      const msgs: ChatMessage[] = [
+        { id: 'msg-1', content: 'Hello world', direction: 'received', timestamp: new Date(), status: 'confirmed' },
+        { id: 'msg-2', content: 'Hello again', direction: 'sent', timestamp: new Date(), status: 'confirmed' },
+      ];
+      mockStore.getState.mockReturnValue({
+        ...defaultStoreState(),
+        chat: { messages: msgs, polling: false, sending: false },
+      });
+      setupChat();
+
+      const output = document.getElementById('chat-output')!;
+      for (const msg of msgs) {
+        const el = document.createElement('div');
+        el.className = 'msg';
+        el.id = `msg-${msg.id}`;
+        el.innerHTML = `<span class="msg__text">${msg.content}</span>`;
+        output.appendChild(el);
+      }
+
+      document.getElementById('btn-search')!.click();
+      const searchInput = document.getElementById('search-input') as HTMLInputElement;
+      searchInput.value = 'Hello';
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+      vi.advanceTimersByTime(200);
+
+      expect(document.getElementById('search-count')!.textContent).toBe('1 of 2 matches');
+
+      // Enter goes to next match
+      searchInput.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+      );
+      expect(document.getElementById('search-count')!.textContent).toBe('2 of 2 matches');
+
+      // Shift+Enter goes to previous
+      searchInput.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', shiftKey: true, bubbles: true })
+      );
+      expect(document.getElementById('search-count')!.textContent).toBe('1 of 2 matches');
+    });
+
+    it('clears highlights when search is closed', () => {
+      const msg: ChatMessage = {
+        id: 'msg-1',
+        content: 'Hello from agent',
+        direction: 'received',
+        timestamp: new Date(),
+        status: 'confirmed',
+      };
+      mockStore.getState.mockReturnValue({
+        ...defaultStoreState(),
+        chat: { messages: [msg], polling: false, sending: false },
+      });
+      setupChat();
+
+      const output = document.getElementById('chat-output')!;
+      const msgEl = document.createElement('div');
+      msgEl.className = 'msg';
+      msgEl.id = 'msg-msg-1';
+      msgEl.innerHTML = '<span class="msg__text">Hello from agent</span>';
+      output.appendChild(msgEl);
+
+      document.getElementById('btn-search')!.click();
+      const searchInput = document.getElementById('search-input') as HTMLInputElement;
+      searchInput.value = 'Hello';
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+      vi.advanceTimersByTime(200);
+
+      expect(msgEl.classList.contains('msg--search-match')).toBe(true);
+
+      document.getElementById('search-close')!.click();
+
+      expect(msgEl.classList.contains('msg--search-match')).toBe(false);
+    });
+  });
+
+  // ── navigation ──
+
+  describe('navigation', () => {
+    it('navigates to settings on settings button click', () => {
+      setupChat();
+      document.getElementById('btn-settings')!.click();
+      expect(mockStore.setView).toHaveBeenCalledWith('settings');
+    });
+  });
+
+  // ── incoming messages ──
+
+  describe('incoming messages', () => {
+    it('appends received messages to the DOM', () => {
+      setupChat();
+
+      expect(messageCallback).not.toBeNull();
+
+      const msg: ChatMessage = {
+        id: 'incoming-1',
+        content: 'Agent response',
+        direction: 'received',
+        timestamp: new Date(),
+        status: 'confirmed',
+      };
+
+      messageCallback!(msg);
+
+      const output = document.getElementById('chat-output')!;
+      const inbound = output.querySelectorAll('.msg--inbound');
+      expect(inbound.length).toBe(1);
+      expect(inbound[0]!.textContent).toContain('Agent response');
+    });
+  });
+
+  // ── cleanupChat ──
+
+  describe('cleanupChat', () => {
+    it('stops polling and cleans up', () => {
+      setupChat();
+      cleanupChat();
+
+      expect(mockMessaging.stopPolling).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/views/scan.test.ts
+++ b/src/views/scan.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Unit tests for the scan view — QR code scanning and manual URI entry
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Hoisted mocks ──
+
+const { mockStore, mockQrScanner, mockToast } = vi.hoisted(() => ({
+  mockStore: {
+    setAgentConnection: vi.fn(),
+    setView: vi.fn(),
+  },
+  mockQrScanner: {
+    startScanning: vi.fn().mockResolvedValue(undefined),
+    stopScanning: vi.fn().mockResolvedValue(undefined),
+    parseManualURI: vi.fn(),
+  },
+  mockToast: {
+    showToast: vi.fn(),
+  },
+}));
+
+vi.mock('../store.ts', () => ({ store: mockStore }));
+vi.mock('../qr-scanner.ts', () => mockQrScanner);
+vi.mock('../toast.ts', () => mockToast);
+
+import { renderScan, bindScanEvents, cleanupScan } from './scan.ts';
+
+// ── Helpers ──
+
+function renderIntoDOM(html: string): void {
+  document.body.innerHTML = `<div id="app">${html}</div>`;
+}
+
+// ── Tests ──
+
+describe('scan view', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  // ── renderScan ──
+
+  describe('renderScan', () => {
+    it('renders the header with title and back button', () => {
+      const html = renderScan();
+      expect(html).toContain('Connect Agent');
+      expect(html).toContain('id="btn-back-setup"');
+    });
+
+    it('renders camera and manual tabs', () => {
+      const html = renderScan();
+      expect(html).toContain('id="tab-camera"');
+      expect(html).toContain('id="tab-manual"');
+    });
+
+    it('renders camera panel visible and manual panel hidden', () => {
+      renderIntoDOM(renderScan());
+      const cameraPanel = document.getElementById('camera-panel');
+      const manualPanel = document.getElementById('manual-panel');
+      expect(cameraPanel).toBeTruthy();
+      expect(manualPanel).toBeTruthy();
+      expect(manualPanel!.style.display).toBe('none');
+    });
+
+    it('renders QR reader element', () => {
+      const html = renderScan();
+      expect(html).toContain('id="qr-reader"');
+    });
+
+    it('renders manual URI input and connect button', () => {
+      const html = renderScan();
+      expect(html).toContain('id="manual-uri"');
+      expect(html).toContain('id="btn-manual-connect"');
+    });
+  });
+
+  // ── bindScanEvents — tab switching ──
+
+  describe('tab switching', () => {
+    beforeEach(() => {
+      renderIntoDOM(renderScan());
+      bindScanEvents();
+    });
+
+    it('switches to manual tab on click', () => {
+      const tabManual = document.getElementById('tab-manual')!;
+      const tabCamera = document.getElementById('tab-camera')!;
+      const cameraPanel = document.getElementById('camera-panel')!;
+      const manualPanel = document.getElementById('manual-panel')!;
+
+      tabManual.click();
+
+      expect(tabManual.className).toContain('tab--active');
+      expect(tabCamera.className).not.toContain('tab--active');
+      expect(cameraPanel.style.display).toBe('none');
+      expect(manualPanel.style.display).toBe('');
+      expect(mockQrScanner.stopScanning).toHaveBeenCalled();
+    });
+
+    it('switches back to camera tab on click', () => {
+      const tabManual = document.getElementById('tab-manual')!;
+      const tabCamera = document.getElementById('tab-camera')!;
+      const cameraPanel = document.getElementById('camera-panel')!;
+      const manualPanel = document.getElementById('manual-panel')!;
+
+      // Switch to manual first
+      tabManual.click();
+      vi.clearAllMocks();
+
+      // Switch back to camera
+      tabCamera.click();
+
+      expect(tabCamera.className).toContain('tab--active');
+      expect(tabManual.className).not.toContain('tab--active');
+      expect(cameraPanel.style.display).toBe('');
+      expect(manualPanel.style.display).toBe('none');
+    });
+  });
+
+  // ── bindScanEvents — camera scanning ──
+
+  describe('camera scanning', () => {
+    it('starts scanning on mount', () => {
+      renderIntoDOM(renderScan());
+      bindScanEvents();
+
+      expect(mockQrScanner.startScanning).toHaveBeenCalledWith(
+        'qr-reader',
+        expect.any(Function)
+      );
+    });
+
+    it('navigates to chat on successful camera scan', () => {
+      renderIntoDOM(renderScan());
+      bindScanEvents();
+
+      const callback = mockQrScanner.startScanning.mock.calls[0]![1] as (
+        result: { success: boolean; connection?: object; error?: string }
+      ) => void;
+
+      const connection = {
+        address: 'AGENT_ADDR',
+        psk: new Uint8Array(32),
+        label: 'MyAgent',
+        network: 'testnet',
+        addedAt: Date.now(),
+      };
+
+      callback({ success: true, connection });
+
+      expect(mockToast.showToast).toHaveBeenCalledWith('Connected to MyAgent', 'success');
+      expect(mockStore.setAgentConnection).toHaveBeenCalledWith(connection);
+      expect(mockStore.setView).toHaveBeenCalledWith('chat');
+    });
+
+    it('shows error toast on failed camera scan', () => {
+      renderIntoDOM(renderScan());
+      bindScanEvents();
+
+      const callback = mockQrScanner.startScanning.mock.calls[0]![1] as (
+        result: { success: boolean; connection?: object; error?: string }
+      ) => void;
+
+      callback({ success: false, error: 'Invalid QR code' });
+
+      expect(mockToast.showToast).toHaveBeenCalledWith('Invalid QR code', 'error');
+      expect(mockStore.setView).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── bindScanEvents — manual connect ──
+
+  describe('manual connect', () => {
+    beforeEach(() => {
+      renderIntoDOM(renderScan());
+      bindScanEvents();
+    });
+
+    it('shows error when manual URI is empty', () => {
+      const uriInput = document.getElementById('manual-uri') as HTMLTextAreaElement;
+      uriInput.value = '';
+
+      document.getElementById('btn-manual-connect')!.click();
+
+      expect(mockToast.showToast).toHaveBeenCalledWith('Please enter a PSK URI', 'error');
+    });
+
+    it('parses valid URI and navigates to chat', () => {
+      const connection = {
+        address: 'AGENT_ADDR',
+        psk: new Uint8Array(32),
+        label: 'ManualAgent',
+        network: 'testnet',
+        addedAt: Date.now(),
+      };
+      mockQrScanner.parseManualURI.mockReturnValue({
+        success: true,
+        connection,
+      });
+
+      const uriInput = document.getElementById('manual-uri') as HTMLTextAreaElement;
+      uriInput.value = 'algochat-psk://v1?addr=AGENT_ADDR&psk=abc&label=ManualAgent';
+
+      document.getElementById('btn-manual-connect')!.click();
+
+      expect(mockQrScanner.parseManualURI).toHaveBeenCalledWith(
+        'algochat-psk://v1?addr=AGENT_ADDR&psk=abc&label=ManualAgent'
+      );
+      expect(mockToast.showToast).toHaveBeenCalledWith('Connected to ManualAgent', 'success');
+      expect(mockStore.setAgentConnection).toHaveBeenCalledWith(connection);
+      expect(mockStore.setView).toHaveBeenCalledWith('chat');
+    });
+
+    it('shows error on invalid manual URI', () => {
+      mockQrScanner.parseManualURI.mockReturnValue({
+        success: false,
+        error: 'Not a valid AlgoChat QR code',
+      });
+
+      const uriInput = document.getElementById('manual-uri') as HTMLTextAreaElement;
+      uriInput.value = 'https://not-a-psk-uri.com';
+
+      document.getElementById('btn-manual-connect')!.click();
+
+      expect(mockToast.showToast).toHaveBeenCalledWith(
+        'Not a valid AlgoChat QR code',
+        'error'
+      );
+      expect(mockStore.setView).not.toHaveBeenCalled();
+    });
+
+    it('shows fallback error message when parseManualURI returns no error string', () => {
+      mockQrScanner.parseManualURI.mockReturnValue({
+        success: false,
+      });
+
+      const uriInput = document.getElementById('manual-uri') as HTMLTextAreaElement;
+      uriInput.value = 'something';
+
+      document.getElementById('btn-manual-connect')!.click();
+
+      expect(mockToast.showToast).toHaveBeenCalledWith('Invalid URI', 'error');
+    });
+  });
+
+  // ── bindScanEvents — back button ──
+
+  describe('back button', () => {
+    it('stops scanning and navigates to setup', () => {
+      renderIntoDOM(renderScan());
+      bindScanEvents();
+
+      document.getElementById('btn-back-setup')!.click();
+
+      expect(mockQrScanner.stopScanning).toHaveBeenCalled();
+      expect(mockStore.setView).toHaveBeenCalledWith('setup');
+    });
+  });
+
+  // ── cleanupScan ──
+
+  describe('cleanupScan', () => {
+    it('calls stopScanning', () => {
+      cleanupScan();
+      expect(mockQrScanner.stopScanning).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/views/settings.test.ts
+++ b/src/views/settings.test.ts
@@ -1,0 +1,517 @@
+/**
+ * Unit tests for the settings view — wallet management, agent info, and danger zone
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { AgentConnection, ChatMessage } from '../types.ts';
+
+// ── Hoisted mocks ──
+
+const {
+  fakeConnection,
+  defaultStoreState,
+  mockStore,
+  mockWallet,
+  mockQrScanner,
+  mockMessaging,
+  mockToast,
+  mockDb,
+  mockIdleLock,
+  mockDeviceName,
+} = vi.hoisted(() => {
+  const fakeConnection: AgentConnection = {
+    address: 'AGENTADDRESS1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEF',
+    psk: new Uint8Array(32),
+    label: 'TestAgent',
+    network: 'testnet',
+    addedAt: Date.now(),
+  };
+
+  const defaultStoreState = (): {
+    view: string;
+    wallet: { address: string | null; unlocked: boolean; balance: number };
+    agent: { connection: AgentConnection | null; online: boolean; lastSeen: number | null };
+    chat: { messages: ChatMessage[]; polling: boolean; sending: boolean };
+  } => ({
+    view: 'settings',
+    wallet: { address: 'WALLETADDR1234567890', unlocked: true, balance: 5_000_000 },
+    agent: { connection: fakeConnection, online: true, lastSeen: Date.now() },
+    chat: { messages: [], polling: false, sending: false },
+  });
+
+  return {
+    fakeConnection,
+    defaultStoreState,
+    mockStore: {
+      getState: vi.fn(defaultStoreState),
+      setView: vi.fn(),
+      lockWallet: vi.fn(),
+      clearAgent: vi.fn(),
+    },
+    mockWallet: {
+      getAccount: vi.fn(),
+      exportMnemonic: vi.fn(),
+      deleteWallet: vi.fn(),
+      lockWallet: vi.fn(),
+    },
+    mockQrScanner: {
+      clearConnection: vi.fn(),
+      loadConnection: vi.fn(() => null),
+    },
+    mockMessaging: {
+      destroy: vi.fn(),
+      stopPolling: vi.fn(),
+    },
+    mockToast: { showToast: vi.fn() },
+    mockDb: { deleteDatabase: vi.fn().mockResolvedValue(undefined) },
+    mockIdleLock: {
+      getIdleTimeout: vi.fn(() => 900_000),
+      setIdleTimeout: vi.fn(),
+      startIdleLock: vi.fn(),
+    },
+    mockDeviceName: {
+      getDeviceName: vi.fn((): string | null => 'mac-studio'),
+      setDeviceName: vi.fn((): boolean => true),
+    },
+  };
+});
+
+vi.mock('../store.ts', () => ({ store: mockStore }));
+vi.mock('../wallet.ts', () => mockWallet);
+vi.mock('../qr-scanner.ts', () => mockQrScanner);
+vi.mock('../messaging.ts', () => ({ messaging: mockMessaging }));
+vi.mock('../toast.ts', () => mockToast);
+vi.mock('../db.ts', () => mockDb);
+vi.mock('../idle-lock.ts', () => mockIdleLock);
+vi.mock('../device-name.ts', () => mockDeviceName);
+vi.mock('../utils.ts', () => ({
+  escapeHtml: (s: string) => s,
+}));
+
+import { renderSettings, bindSettingsEvents } from './settings.ts';
+
+// ── Helpers ──
+
+function renderIntoDOM(html: string): void {
+  document.body.innerHTML = `<div id="app">${html}</div>`;
+}
+
+function setup(): void {
+  renderIntoDOM(renderSettings());
+  bindSettingsEvents();
+}
+
+// ── Tests ──
+
+describe('settings view', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+    mockStore.getState.mockImplementation(defaultStoreState);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  // ── renderSettings ──
+
+  describe('renderSettings', () => {
+    it('renders the header with title and back button', () => {
+      const html = renderSettings();
+      expect(html).toContain('Settings');
+      expect(html).toContain('id="btn-back-chat"');
+    });
+
+    it('renders wallet address', () => {
+      const html = renderSettings();
+      expect(html).toContain('WALLETADDR1234567890');
+    });
+
+    it('renders balance in ALGO', () => {
+      const html = renderSettings();
+      expect(html).toContain('5.0000 ALGO');
+      expect(html).toContain('5,000,000');
+    });
+
+    it('renders auto-lock timeout field', () => {
+      const html = renderSettings();
+      expect(html).toContain('id="idle-timeout"');
+      expect(html).toContain('Auto-lock timeout');
+    });
+
+    it('renders device name field', () => {
+      const html = renderSettings();
+      expect(html).toContain('id="device-name"');
+      expect(html).toContain('mac-studio');
+    });
+
+    it('renders export mnemonic and lock wallet buttons', () => {
+      const html = renderSettings();
+      expect(html).toContain('id="btn-export-mnemonic"');
+      expect(html).toContain('id="btn-lock-wallet"');
+    });
+
+    it('renders agent connection info when agent is connected', () => {
+      const html = renderSettings();
+      expect(html).toContain('TestAgent');
+      expect(html).toContain('AGENTADDRESS');
+      expect(html).toContain('testnet');
+      expect(html).toContain('Online');
+      expect(html).toContain('id="btn-reconnect"');
+      expect(html).toContain('id="btn-disconnect"');
+    });
+
+    it('renders "No agent connected" when agent is null', () => {
+      mockStore.getState.mockReturnValue({
+        ...defaultStoreState(),
+        agent: { connection: null, online: false, lastSeen: null },
+      });
+
+      const html = renderSettings();
+      expect(html).toContain('No agent connected');
+      expect(html).toContain('id="btn-scan-agent"');
+    });
+
+    it('renders offline status when agent is not online', () => {
+      mockStore.getState.mockReturnValue({
+        ...defaultStoreState(),
+        agent: { connection: fakeConnection, online: false, lastSeen: null },
+      });
+
+      const html = renderSettings();
+      expect(html).toContain('Offline');
+      expect(html).toContain('status-dot--grey');
+    });
+
+    it('renders danger zone with delete button', () => {
+      const html = renderSettings();
+      expect(html).toContain('Danger Zone');
+      expect(html).toContain('id="btn-delete-all"');
+    });
+
+    it('renders ecosystem links', () => {
+      const html = renderSettings();
+      expect(html).toContain('Ecosystem');
+      expect(html).toContain('corvid-agent.github.io');
+    });
+  });
+
+  // ── back button ──
+
+  describe('back button', () => {
+    it('navigates to chat when agent is connected', () => {
+      setup();
+      document.getElementById('btn-back-chat')!.click();
+      expect(mockStore.setView).toHaveBeenCalledWith('chat');
+    });
+
+    it('navigates to setup when no agent is connected', () => {
+      mockStore.getState.mockReturnValue({
+        ...defaultStoreState(),
+        agent: { connection: null, online: false, lastSeen: null },
+      });
+      setup();
+      document.getElementById('btn-back-chat')!.click();
+      expect(mockStore.setView).toHaveBeenCalledWith('setup');
+    });
+  });
+
+  // ── idle timeout ──
+
+  describe('idle timeout setting', () => {
+    it('updates idle timeout on valid input', () => {
+      setup();
+      const input = document.getElementById('idle-timeout') as HTMLInputElement;
+      input.value = '30';
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+
+      expect(mockIdleLock.setIdleTimeout).toHaveBeenCalledWith(30);
+      expect(mockIdleLock.startIdleLock).toHaveBeenCalled();
+      expect(mockToast.showToast).toHaveBeenCalledWith('Auto-lock set to 30 min', 'info');
+    });
+
+    it('rejects invalid timeout value above maximum', () => {
+      setup();
+      const input = document.getElementById('idle-timeout') as HTMLInputElement;
+      input.value = '200';
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+
+      expect(mockIdleLock.setIdleTimeout).not.toHaveBeenCalled();
+      expect(mockToast.showToast).toHaveBeenCalledWith(
+        'Timeout must be 1-120 minutes',
+        'error'
+      );
+    });
+
+    it('rejects zero timeout value', () => {
+      setup();
+      const input = document.getElementById('idle-timeout') as HTMLInputElement;
+      input.value = '0';
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+
+      expect(mockIdleLock.setIdleTimeout).not.toHaveBeenCalled();
+      expect(mockToast.showToast).toHaveBeenCalledWith(
+        'Timeout must be 1-120 minutes',
+        'error'
+      );
+    });
+  });
+
+  // ── device name ──
+
+  describe('device name setting', () => {
+    it('updates device name on valid input', () => {
+      setup();
+      const input = document.getElementById('device-name') as HTMLInputElement;
+      input.value = 'my-phone';
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+
+      expect(mockDeviceName.setDeviceName).toHaveBeenCalledWith('my-phone');
+      expect(mockToast.showToast).toHaveBeenCalledWith(
+        'Device name set to "my-phone"',
+        'info'
+      );
+    });
+
+    it('shows cleared message when name is set to empty', () => {
+      setup();
+      const input = document.getElementById('device-name') as HTMLInputElement;
+      input.value = '';
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+
+      expect(mockDeviceName.setDeviceName).toHaveBeenCalledWith('');
+      expect(mockToast.showToast).toHaveBeenCalledWith('Device name cleared', 'info');
+    });
+
+    it('shows error on invalid device name', () => {
+      mockDeviceName.setDeviceName.mockReturnValueOnce(false);
+      setup();
+      const input = document.getElementById('device-name') as HTMLInputElement;
+      input.value = 'invalid name!!!';
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+
+      expect(mockToast.showToast).toHaveBeenCalledWith(
+        'Invalid name (letters, numbers, hyphens, underscores, max 16)',
+        'error'
+      );
+    });
+  });
+
+  // ── export mnemonic ──
+
+  describe('export mnemonic flow', () => {
+    it('shows password modal on export button click', () => {
+      setup();
+      document.getElementById('btn-export-mnemonic')!.click();
+
+      const overlay = document.querySelector('.modal-overlay');
+      expect(overlay).toBeTruthy();
+      expect(overlay!.textContent).toContain('Export Mnemonic');
+      expect(document.getElementById('export-pw-input')).toBeTruthy();
+      expect(document.getElementById('export-pw-confirm')).toBeTruthy();
+      expect(document.getElementById('export-pw-cancel')).toBeTruthy();
+    });
+
+    it('dismisses password modal on cancel', () => {
+      setup();
+      document.getElementById('btn-export-mnemonic')!.click();
+
+      document.getElementById('export-pw-cancel')!.click();
+
+      expect(document.querySelector('.modal-overlay')).toBeNull();
+    });
+
+    it('shows error when password is empty', () => {
+      setup();
+      document.getElementById('btn-export-mnemonic')!.click();
+
+      const pwInput = document.getElementById('export-pw-input') as HTMLInputElement;
+      pwInput.value = '';
+      document.getElementById('export-pw-confirm')!.click();
+
+      expect(mockToast.showToast).toHaveBeenCalledWith('Enter your password', 'error');
+    });
+
+    it('shows mnemonic modal on successful export', async () => {
+      mockWallet.exportMnemonic.mockResolvedValue(
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent'
+      );
+
+      setup();
+      document.getElementById('btn-export-mnemonic')!.click();
+
+      const pwInput = document.getElementById('export-pw-input') as HTMLInputElement;
+      pwInput.value = 'correctpassword';
+      document.getElementById('export-pw-confirm')!.click();
+
+      await vi.waitFor(() => {
+        expect(mockWallet.exportMnemonic).toHaveBeenCalledWith('correctpassword');
+        const overlays = document.querySelectorAll('.modal-overlay');
+        expect(overlays.length).toBe(1);
+        expect(overlays[0]!.textContent).toContain('Your Mnemonic');
+        expect(overlays[0]!.textContent).toContain('abandon');
+      });
+    });
+
+    it('shows error toast on export failure', async () => {
+      mockWallet.exportMnemonic.mockRejectedValue(new Error('Wrong password'));
+
+      setup();
+      document.getElementById('btn-export-mnemonic')!.click();
+
+      const pwInput = document.getElementById('export-pw-input') as HTMLInputElement;
+      pwInput.value = 'wrongpassword';
+      document.getElementById('export-pw-confirm')!.click();
+
+      await vi.waitFor(() => {
+        expect(mockToast.showToast).toHaveBeenCalledWith('Wrong password', 'error');
+      });
+    });
+
+    it('closes mnemonic modal on close button', async () => {
+      mockWallet.exportMnemonic.mockResolvedValue('test mnemonic words');
+
+      setup();
+      document.getElementById('btn-export-mnemonic')!.click();
+
+      const pwInput = document.getElementById('export-pw-input') as HTMLInputElement;
+      pwInput.value = 'password';
+      document.getElementById('export-pw-confirm')!.click();
+
+      await vi.waitFor(() => {
+        expect(document.getElementById('btn-close-mnemonic')).toBeTruthy();
+      });
+
+      document.getElementById('btn-close-mnemonic')!.click();
+
+      expect(document.querySelector('.modal-overlay')).toBeNull();
+    });
+
+    it('exports mnemonic on Enter key in password field', async () => {
+      mockWallet.exportMnemonic.mockResolvedValue('test mnemonic words');
+
+      setup();
+      document.getElementById('btn-export-mnemonic')!.click();
+
+      const pwInput = document.getElementById('export-pw-input') as HTMLInputElement;
+      pwInput.value = 'password';
+      pwInput.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+      );
+
+      await vi.waitFor(() => {
+        expect(mockWallet.exportMnemonic).toHaveBeenCalledWith('password');
+      });
+    });
+  });
+
+  // ── lock wallet ──
+
+  describe('lock wallet', () => {
+    it('locks wallet and shows toast', () => {
+      setup();
+      document.getElementById('btn-lock-wallet')!.click();
+
+      expect(mockMessaging.destroy).toHaveBeenCalled();
+      expect(mockWallet.lockWallet).toHaveBeenCalled();
+      expect(mockStore.lockWallet).toHaveBeenCalled();
+      expect(mockToast.showToast).toHaveBeenCalledWith('Wallet locked', 'info');
+    });
+  });
+
+  // ── scan new agent ──
+
+  describe('scan new agent', () => {
+    it('stops polling and navigates to scan', () => {
+      setup();
+      document.getElementById('btn-reconnect')!.click();
+
+      expect(mockMessaging.stopPolling).toHaveBeenCalled();
+      expect(mockStore.setView).toHaveBeenCalledWith('scan');
+    });
+  });
+
+  // ── disconnect agent ──
+
+  describe('disconnect agent', () => {
+    it('disconnects when user confirms', () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(true);
+      setup();
+      document.getElementById('btn-disconnect')!.click();
+
+      expect(mockMessaging.destroy).toHaveBeenCalled();
+      expect(mockQrScanner.clearConnection).toHaveBeenCalled();
+      expect(mockStore.clearAgent).toHaveBeenCalled();
+      expect(mockToast.showToast).toHaveBeenCalledWith('Disconnected', 'info');
+      expect(mockStore.setView).toHaveBeenCalledWith('scan');
+    });
+
+    it('does nothing when user cancels disconnect', () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(false);
+      setup();
+      document.getElementById('btn-disconnect')!.click();
+
+      expect(mockMessaging.destroy).not.toHaveBeenCalled();
+      expect(mockQrScanner.clearConnection).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── delete all data ──
+
+  describe('delete all data', () => {
+    it('deletes everything when user confirms', async () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+      // Node.js built-in localStorage lacks .clear() — create a full mock
+      const store = new Map<string, string>();
+      const clearFn = vi.fn(() => store.clear());
+      vi.stubGlobal('localStorage', {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, val: string) => store.set(key, String(val)),
+        removeItem: (key: string) => store.delete(key),
+        key: (idx: number) => [...store.keys()][idx] ?? null,
+        get length() { return store.size; },
+        clear: clearFn,
+      });
+
+      setup();
+      document.getElementById('btn-delete-all')!.click();
+
+      await vi.waitFor(() => {
+        expect(mockMessaging.destroy).toHaveBeenCalled();
+        expect(mockQrScanner.clearConnection).toHaveBeenCalled();
+        expect(mockWallet.deleteWallet).toHaveBeenCalled();
+        expect(mockDb.deleteDatabase).toHaveBeenCalled();
+        expect(clearFn).toHaveBeenCalled();
+        expect(mockStore.lockWallet).toHaveBeenCalled();
+        expect(mockToast.showToast).toHaveBeenCalledWith('All data deleted', 'info');
+      });
+
+      vi.unstubAllGlobals();
+    });
+
+    it('does nothing when user cancels deletion', () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(false);
+      setup();
+      document.getElementById('btn-delete-all')!.click();
+
+      expect(mockMessaging.destroy).not.toHaveBeenCalled();
+      expect(mockWallet.deleteWallet).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── scan agent (no agent connected) ──
+
+  describe('scan agent when none connected', () => {
+    it('navigates to scan view', () => {
+      mockStore.getState.mockReturnValue({
+        ...defaultStoreState(),
+        agent: { connection: null, online: false, lastSeen: null },
+      });
+      setup();
+      document.getElementById('btn-scan-agent')!.click();
+
+      expect(mockStore.setView).toHaveBeenCalledWith('scan');
+    });
+  });
+});

--- a/src/views/setup.test.ts
+++ b/src/views/setup.test.ts
@@ -1,0 +1,506 @@
+/**
+ * Unit tests for the setup view — wallet creation, import, unlock, and reset flows
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Hoisted mocks (vi.mock is hoisted, so variables must be too) ──
+
+const { mockStore, mockWallet, mockQrScanner, mockToast } = vi.hoisted(() => ({
+  mockStore: {
+    setWallet: vi.fn(),
+    setAgentConnection: vi.fn(),
+    setView: vi.fn(),
+  },
+  mockWallet: {
+    hasStoredWallet: vi.fn((): boolean => false),
+    getStoredWallet: vi.fn((): unknown => null),
+    createWallet: vi.fn(),
+    importWallet: vi.fn(),
+    unlockWallet: vi.fn(),
+    deleteWallet: vi.fn(),
+  },
+  mockQrScanner: {
+    loadConnection: vi.fn((): unknown => null),
+  },
+  mockToast: {
+    showToast: vi.fn(),
+  },
+}));
+
+vi.mock('../store.ts', () => ({ store: mockStore }));
+vi.mock('../wallet.ts', () => mockWallet);
+vi.mock('../qr-scanner.ts', () => mockQrScanner);
+vi.mock('../toast.ts', () => mockToast);
+
+import { renderSetup, bindSetupEvents } from './setup.ts';
+
+// ── Helpers ──
+
+function renderIntoDOM(html: string): void {
+  document.body.innerHTML = `<div id="app">${html}</div>`;
+}
+
+// ── Tests ──
+
+describe('setup view', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  // ── renderSetup ──
+
+  describe('renderSetup', () => {
+    it('renders the create/import view when no wallet is stored', () => {
+      mockWallet.hasStoredWallet.mockReturnValue(false);
+      mockWallet.getStoredWallet.mockReturnValue(null);
+
+      const html = renderSetup();
+
+      expect(html).toContain('Create Wallet');
+      expect(html).toContain('Import Wallet');
+      expect(html).toContain('id="btn-create"');
+      expect(html).toContain('id="btn-import"');
+      expect(html).toContain('id="create-password"');
+      expect(html).toContain('id="create-password-confirm"');
+      expect(html).toContain('id="import-mnemonic"');
+      expect(html).toContain('id="import-password"');
+    });
+
+    it('renders the unlock view when a wallet is stored', () => {
+      mockWallet.hasStoredWallet.mockReturnValue(true);
+      mockWallet.getStoredWallet.mockReturnValue({
+        address: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWX',
+        encryptedMnemonic: 'enc',
+        iv: 'iv',
+        salt: 'salt',
+      });
+
+      const html = renderSetup();
+
+      expect(html).toContain('Unlock Wallet');
+      expect(html).toContain('id="btn-unlock"');
+      expect(html).toContain('id="unlock-password"');
+      expect(html).toContain('id="btn-reset-wallet"');
+      expect(html).toContain('ABCDEF');
+      expect(html).toContain('...');
+    });
+
+    it('shows "Agent connection saved" hint when a saved agent exists on unlock view', () => {
+      mockWallet.hasStoredWallet.mockReturnValue(true);
+      mockWallet.getStoredWallet.mockReturnValue({
+        address: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWX',
+        encryptedMnemonic: 'enc',
+        iv: 'iv',
+        salt: 'salt',
+      });
+      mockQrScanner.loadConnection.mockReturnValue({
+        address: 'AGENT_ADDR',
+        psk: new Uint8Array(32),
+        label: 'TestAgent',
+        network: 'testnet',
+        addedAt: Date.now(),
+      });
+
+      const html = renderSetup();
+      expect(html).toContain('Agent connection saved');
+    });
+
+    it('does not show "Agent connection saved" when no saved agent exists', () => {
+      mockWallet.hasStoredWallet.mockReturnValue(true);
+      mockWallet.getStoredWallet.mockReturnValue({
+        address: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWX',
+        encryptedMnemonic: 'enc',
+        iv: 'iv',
+        salt: 'salt',
+      });
+      mockQrScanner.loadConnection.mockReturnValue(null);
+
+      const html = renderSetup();
+      expect(html).not.toContain('Agent connection saved');
+    });
+  });
+
+  // ── bindSetupEvents — create wallet ──
+
+  describe('create wallet flow', () => {
+    beforeEach(() => {
+      mockWallet.hasStoredWallet.mockReturnValue(false);
+      mockWallet.getStoredWallet.mockReturnValue(null);
+      renderIntoDOM(renderSetup());
+      bindSetupEvents();
+    });
+
+    it('shows error toast when password is too short', async () => {
+      const pwInput = document.getElementById('create-password') as HTMLInputElement;
+      const confirmInput = document.getElementById('create-password-confirm') as HTMLInputElement;
+      pwInput.value = 'short';
+      confirmInput.value = 'short';
+
+      document.getElementById('btn-create')!.click();
+      await vi.waitFor(() => {
+        expect(mockToast.showToast).toHaveBeenCalledWith(
+          'Password must be at least 8 characters',
+          'error'
+        );
+      });
+    });
+
+    it('shows error toast when passwords do not match', async () => {
+      const pwInput = document.getElementById('create-password') as HTMLInputElement;
+      const confirmInput = document.getElementById('create-password-confirm') as HTMLInputElement;
+      pwInput.value = 'longpassword1';
+      confirmInput.value = 'longpassword2';
+
+      document.getElementById('btn-create')!.click();
+      await vi.waitFor(() => {
+        expect(mockToast.showToast).toHaveBeenCalledWith(
+          'Passwords do not match',
+          'error'
+        );
+      });
+    });
+
+    it('creates wallet and navigates to scan when no saved agent', async () => {
+      mockWallet.createWallet.mockResolvedValue({ address: 'NEW_ADDR' });
+      mockQrScanner.loadConnection.mockReturnValue(null);
+
+      const pwInput = document.getElementById('create-password') as HTMLInputElement;
+      const confirmInput = document.getElementById('create-password-confirm') as HTMLInputElement;
+      pwInput.value = 'validpassword';
+      confirmInput.value = 'validpassword';
+
+      document.getElementById('btn-create')!.click();
+
+      await vi.waitFor(() => {
+        expect(mockWallet.createWallet).toHaveBeenCalledWith('validpassword');
+        expect(mockStore.setWallet).toHaveBeenCalledWith('NEW_ADDR');
+        expect(mockToast.showToast).toHaveBeenCalledWith('Wallet created!', 'success');
+        expect(mockStore.setView).toHaveBeenCalledWith('scan');
+      });
+    });
+
+    it('creates wallet and navigates to chat when saved agent exists', async () => {
+      const savedAgent = {
+        address: 'AGENT_ADDR',
+        psk: new Uint8Array(32),
+        label: 'TestAgent',
+        network: 'testnet' as const,
+        addedAt: Date.now(),
+      };
+      mockWallet.createWallet.mockResolvedValue({ address: 'NEW_ADDR' });
+      mockQrScanner.loadConnection.mockReturnValue(savedAgent);
+
+      const pwInput = document.getElementById('create-password') as HTMLInputElement;
+      const confirmInput = document.getElementById('create-password-confirm') as HTMLInputElement;
+      pwInput.value = 'validpassword';
+      confirmInput.value = 'validpassword';
+
+      document.getElementById('btn-create')!.click();
+
+      await vi.waitFor(() => {
+        expect(mockStore.setAgentConnection).toHaveBeenCalledWith(savedAgent);
+        expect(mockStore.setView).toHaveBeenCalledWith('chat');
+      });
+    });
+
+    it('disables button and shows loading text during creation', async () => {
+      let resolveCreate!: (val: { address: string }) => void;
+      mockWallet.createWallet.mockImplementation(
+        () => new Promise((r) => { resolveCreate = r; })
+      );
+
+      const pwInput = document.getElementById('create-password') as HTMLInputElement;
+      const confirmInput = document.getElementById('create-password-confirm') as HTMLInputElement;
+      pwInput.value = 'validpassword';
+      confirmInput.value = 'validpassword';
+
+      const btn = document.getElementById('btn-create')!;
+      btn.click();
+
+      await vi.waitFor(() => {
+        expect(btn.getAttribute('disabled')).toBe('true');
+        expect(btn.textContent).toBe('Generating...');
+      });
+
+      resolveCreate({ address: 'NEW_ADDR' });
+    });
+
+    it('shows error and re-enables button on creation failure', async () => {
+      mockWallet.createWallet.mockRejectedValue(new Error('Crypto failed'));
+
+      const pwInput = document.getElementById('create-password') as HTMLInputElement;
+      const confirmInput = document.getElementById('create-password-confirm') as HTMLInputElement;
+      pwInput.value = 'validpassword';
+      confirmInput.value = 'validpassword';
+
+      const btn = document.getElementById('btn-create')!;
+      btn.click();
+
+      await vi.waitFor(() => {
+        expect(mockToast.showToast).toHaveBeenCalledWith('Failed: Crypto failed', 'error');
+        expect(btn.getAttribute('disabled')).toBeNull();
+        expect(btn.textContent).toBe('Generate New Wallet');
+      });
+    });
+  });
+
+  // ── bindSetupEvents — import wallet ──
+
+  describe('import wallet flow', () => {
+    beforeEach(() => {
+      mockWallet.hasStoredWallet.mockReturnValue(false);
+      mockWallet.getStoredWallet.mockReturnValue(null);
+      renderIntoDOM(renderSetup());
+      bindSetupEvents();
+    });
+
+    it('shows error when mnemonic is empty', async () => {
+      const mnemonicInput = document.getElementById('import-mnemonic') as HTMLTextAreaElement;
+      const pwInput = document.getElementById('import-password') as HTMLInputElement;
+      mnemonicInput.value = '';
+      pwInput.value = 'validpassword';
+
+      document.getElementById('btn-import')!.click();
+
+      await vi.waitFor(() => {
+        expect(mockToast.showToast).toHaveBeenCalledWith(
+          'Please enter a valid 25-word mnemonic',
+          'error'
+        );
+      });
+    });
+
+    it('shows error when mnemonic has wrong word count', async () => {
+      const mnemonicInput = document.getElementById('import-mnemonic') as HTMLTextAreaElement;
+      const pwInput = document.getElementById('import-password') as HTMLInputElement;
+      mnemonicInput.value = 'word1 word2 word3';
+      pwInput.value = 'validpassword';
+
+      document.getElementById('btn-import')!.click();
+
+      await vi.waitFor(() => {
+        expect(mockToast.showToast).toHaveBeenCalledWith(
+          'Please enter a valid 25-word mnemonic',
+          'error'
+        );
+      });
+    });
+
+    it('shows error when import password is too short', async () => {
+      const words = Array.from({ length: 25 }, (_, i) => `word${i}`).join(' ');
+      const mnemonicInput = document.getElementById('import-mnemonic') as HTMLTextAreaElement;
+      const pwInput = document.getElementById('import-password') as HTMLInputElement;
+      mnemonicInput.value = words;
+      pwInput.value = 'short';
+
+      document.getElementById('btn-import')!.click();
+
+      await vi.waitFor(() => {
+        expect(mockToast.showToast).toHaveBeenCalledWith(
+          'Password must be at least 8 characters',
+          'error'
+        );
+      });
+    });
+
+    it('imports wallet and navigates to scan when no saved agent', async () => {
+      const words = Array.from({ length: 25 }, (_, i) => `word${i}`).join(' ');
+      mockWallet.importWallet.mockResolvedValue({ address: 'IMPORTED_ADDR' });
+      mockQrScanner.loadConnection.mockReturnValue(null);
+
+      const mnemonicInput = document.getElementById('import-mnemonic') as HTMLTextAreaElement;
+      const pwInput = document.getElementById('import-password') as HTMLInputElement;
+      mnemonicInput.value = words;
+      pwInput.value = 'validpassword';
+
+      document.getElementById('btn-import')!.click();
+
+      await vi.waitFor(() => {
+        expect(mockWallet.importWallet).toHaveBeenCalledWith(words, 'validpassword');
+        expect(mockStore.setWallet).toHaveBeenCalledWith('IMPORTED_ADDR');
+        expect(mockToast.showToast).toHaveBeenCalledWith('Wallet imported!', 'success');
+        expect(mockStore.setView).toHaveBeenCalledWith('scan');
+      });
+    });
+
+    it('shows error and re-enables button on import failure', async () => {
+      const words = Array.from({ length: 25 }, (_, i) => `word${i}`).join(' ');
+      mockWallet.importWallet.mockRejectedValue(new Error('Invalid mnemonic'));
+
+      const mnemonicInput = document.getElementById('import-mnemonic') as HTMLTextAreaElement;
+      const pwInput = document.getElementById('import-password') as HTMLInputElement;
+      mnemonicInput.value = words;
+      pwInput.value = 'validpassword';
+
+      const btn = document.getElementById('btn-import')!;
+      btn.click();
+
+      await vi.waitFor(() => {
+        expect(mockToast.showToast).toHaveBeenCalledWith('Failed: Invalid mnemonic', 'error');
+        expect(btn.getAttribute('disabled')).toBeNull();
+        expect(btn.textContent).toBe('Import Wallet');
+      });
+    });
+  });
+
+  // ── bindSetupEvents — unlock wallet ──
+
+  describe('unlock wallet flow', () => {
+    beforeEach(() => {
+      mockWallet.hasStoredWallet.mockReturnValue(true);
+      mockWallet.getStoredWallet.mockReturnValue({
+        address: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWX',
+        encryptedMnemonic: 'enc',
+        iv: 'iv',
+        salt: 'salt',
+      });
+      mockQrScanner.loadConnection.mockReturnValue(null);
+      renderIntoDOM(renderSetup());
+      bindSetupEvents();
+    });
+
+    it('shows error when password is empty', async () => {
+      const pwInput = document.getElementById('unlock-password') as HTMLInputElement;
+      pwInput.value = '';
+
+      document.getElementById('btn-unlock')!.click();
+
+      await vi.waitFor(() => {
+        expect(mockToast.showToast).toHaveBeenCalledWith(
+          'Please enter your password',
+          'error'
+        );
+      });
+    });
+
+    it('unlocks wallet and navigates to scan when no saved agent', async () => {
+      mockWallet.unlockWallet.mockResolvedValue({ address: 'UNLOCKED_ADDR' });
+
+      const pwInput = document.getElementById('unlock-password') as HTMLInputElement;
+      pwInput.value = 'mypassword';
+
+      document.getElementById('btn-unlock')!.click();
+
+      await vi.waitFor(() => {
+        expect(mockWallet.unlockWallet).toHaveBeenCalledWith('mypassword');
+        expect(mockStore.setWallet).toHaveBeenCalledWith('UNLOCKED_ADDR');
+        expect(mockStore.setView).toHaveBeenCalledWith('scan');
+      });
+    });
+
+    it('unlocks wallet and navigates to chat when saved agent exists', async () => {
+      const savedAgent = {
+        address: 'AGENT_ADDR',
+        psk: new Uint8Array(32),
+        label: 'TestAgent',
+        network: 'testnet' as const,
+        addedAt: Date.now(),
+      };
+      mockWallet.unlockWallet.mockResolvedValue({ address: 'UNLOCKED_ADDR' });
+      mockQrScanner.loadConnection.mockReturnValue(savedAgent);
+
+      renderIntoDOM(renderSetup());
+      bindSetupEvents();
+
+      const pwInput = document.getElementById('unlock-password') as HTMLInputElement;
+      pwInput.value = 'mypassword';
+      document.getElementById('btn-unlock')!.click();
+
+      await vi.waitFor(() => {
+        expect(mockStore.setAgentConnection).toHaveBeenCalledWith(savedAgent);
+        expect(mockStore.setView).toHaveBeenCalledWith('chat');
+      });
+    });
+
+    it('shows "Wrong password" on invalid password error', async () => {
+      mockWallet.unlockWallet.mockRejectedValue(new Error('Invalid password'));
+
+      const pwInput = document.getElementById('unlock-password') as HTMLInputElement;
+      pwInput.value = 'wrongpassword';
+
+      document.getElementById('btn-unlock')!.click();
+
+      await vi.waitFor(() => {
+        expect(mockToast.showToast).toHaveBeenCalledWith('Wrong password', 'error');
+      });
+    });
+
+    it('shows "Unlock failed" on non-password error', async () => {
+      mockWallet.unlockWallet.mockRejectedValue(new Error('Database corrupt'));
+
+      const pwInput = document.getElementById('unlock-password') as HTMLInputElement;
+      pwInput.value = 'somepassword';
+
+      document.getElementById('btn-unlock')!.click();
+
+      await vi.waitFor(() => {
+        expect(mockToast.showToast).toHaveBeenCalledWith('Unlock failed', 'error');
+      });
+    });
+
+    it('unlocks on Enter key press in password field', async () => {
+      mockWallet.unlockWallet.mockResolvedValue({ address: 'UNLOCKED_ADDR' });
+
+      const pwInput = document.getElementById('unlock-password') as HTMLInputElement;
+      pwInput.value = 'mypassword';
+      pwInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+      await vi.waitFor(() => {
+        expect(mockWallet.unlockWallet).toHaveBeenCalledWith('mypassword');
+      });
+    });
+
+    it('re-enables button after unlock failure', async () => {
+      mockWallet.unlockWallet.mockRejectedValue(new Error('Invalid password'));
+
+      const pwInput = document.getElementById('unlock-password') as HTMLInputElement;
+      pwInput.value = 'wrong';
+      const btn = document.getElementById('btn-unlock')!;
+      btn.click();
+
+      await vi.waitFor(() => {
+        expect(btn.getAttribute('disabled')).toBeNull();
+        expect(btn.textContent).toBe('Unlock');
+      });
+    });
+  });
+
+  // ── bindSetupEvents — reset wallet ──
+
+  describe('reset wallet flow', () => {
+    beforeEach(() => {
+      mockWallet.hasStoredWallet.mockReturnValue(true);
+      mockWallet.getStoredWallet.mockReturnValue({
+        address: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWX',
+        encryptedMnemonic: 'enc',
+        iv: 'iv',
+        salt: 'salt',
+      });
+      renderIntoDOM(renderSetup());
+      bindSetupEvents();
+    });
+
+    it('deletes wallet when user confirms reset', () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+      document.getElementById('btn-reset-wallet')!.click();
+
+      expect(mockWallet.deleteWallet).toHaveBeenCalled();
+      expect(mockToast.showToast).toHaveBeenCalledWith('Wallet deleted', 'info');
+      expect(mockStore.setView).toHaveBeenCalledWith('setup');
+    });
+
+    it('does nothing when user cancels reset', () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+      document.getElementById('btn-reset-wallet')!.click();
+
+      expect(mockWallet.deleteWallet).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for setup, scan, chat, and settings view modules
- Cover DOM rendering, user interactions, state changes, and error paths
- All tests use vitest + jsdom with mocked dependencies

## Test plan
- [x] `npx vitest run` — all tests pass
- [x] `npx tsc --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)