### PR TITLE
refactor: extract localStorage mock into shared test utility

### DIFF
--- a/src/qr-scanner.test.ts
+++ b/src/qr-scanner.test.ts
@@ -4,17 +4,9 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { bufferToBase64 } from './utils.ts';
+import { stubLocalStorage } from './test-utils.ts';
 
-// Node.js built-in localStorage lacks .clear() and .removeItem() — provide a full mock
-const store = new Map<string, string>();
-vi.stubGlobal('localStorage', {
-  getItem: (key: string) => store.get(key) ?? null,
-  setItem: (key: string, val: string) => { store.set(key, String(val)); },
-  removeItem: (key: string) => { store.delete(key); },
-  clear: () => { store.clear(); },
-  get length() { return store.size; },
-  key: (i: number) => [...store.keys()][i] ?? null,
-});
+const { store } = stubLocalStorage();
 
 /** Encode Uint8Array to base64url (no padding) — mirrors ts-algochat encoding */
 function toBase64Url(data: Uint8Array): string {

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,0 +1,28 @@
+import { vi } from 'vitest';
+
+/**
+ * Stub `globalThis.localStorage` with a Map-backed implementation.
+ * Node.js's built-in localStorage lacks `.clear()` and `.removeItem()`,
+ * so tests that touch localStorage need this full mock.
+ *
+ * Returns the backing store and individual method spies for assertions.
+ */
+export function stubLocalStorage() {
+  const store = new Map<string, string>();
+  const getItem = vi.fn((key: string) => store.get(key) ?? null);
+  const setItem = vi.fn((key: string, val: string) => { store.set(key, String(val)); });
+  const removeItem = vi.fn((key: string) => { store.delete(key); });
+  const clear = vi.fn(() => { store.clear(); });
+  const key = vi.fn((i: number) => [...store.keys()][i] ?? null);
+
+  vi.stubGlobal('localStorage', {
+    getItem,
+    setItem,
+    removeItem,
+    clear,
+    get length() { return store.size; },
+    key,
+  });
+
+  return { store, getItem, setItem, removeItem, clear, key };
+}

--- a/src/views/settings.test.ts
+++ b/src/views/settings.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { AgentConnection, ChatMessage } from '../types.ts';
+import { stubLocalStorage } from '../test-utils.ts';
 
 // ── Hoisted mocks ──
 
@@ -462,17 +463,7 @@ describe('settings view', () => {
     it('deletes everything when user confirms', async () => {
       vi.spyOn(window, 'confirm').mockReturnValue(true);
 
-      // Node.js built-in localStorage lacks .clear() — create a full mock
-      const store = new Map<string, string>();
-      const clearFn = vi.fn(() => store.clear());
-      vi.stubGlobal('localStorage', {
-        getItem: (key: string) => store.get(key) ?? null,
-        setItem: (key: string, val: string) => store.set(key, String(val)),
-        removeItem: (key: string) => store.delete(key),
-        key: (idx: number) => [...store.keys()][idx] ?? null,
-        get length() { return store.size; },
-        clear: clearFn,
-      });
+      const { clear: clearFn } = stubLocalStorage();
 
       setup();
       document.getElementById('btn-delete-all')!.click();


### PR DESCRIPTION
## Summary
- Create `src/test-utils.ts` with `stubLocalStorage()` helper — closes #20
- Replace duplicate Map-backed localStorage mocks in `qr-scanner.test.ts` and `settings.test.ts`
- All method spies (`getItem`, `setItem`, `removeItem`, `clear`, `key`) are returned for assertions

## Changes
- **New file:** `src/test-utils.ts` — shared `stubLocalStorage()` utility
- **Updated:** `src/qr-scanner.test.ts` — replaced 9-line inline mock with 1-line import
- **Updated:** `src/views/settings.test.ts` — replaced 8-line inline mock with 1-line import

## Test plan
- [x] All 257 tests pass (`vitest run`)
- [x] No behavior changes — same Map-backed implementation, now with vi.fn() spies on all methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)