### PR TITLE
feat: add keyboard shortcut help overlay

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -545,6 +545,46 @@ html, body {
     justify-content: flex-end;
 }
 
+/* ── Keyboard shortcuts overlay ── */
+.shortcuts-modal {
+    max-width: 380px;
+}
+.shortcuts-list {
+    display: flex; flex-direction: column; gap: 0.75rem;
+}
+.shortcuts-group__title {
+    font-size: 0.875rem; font-weight: 700;
+    color: var(--accent-cyan);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 0.375rem;
+}
+.shortcut-row {
+    display: flex; align-items: center;
+    justify-content: space-between;
+    padding: 0.25rem 0;
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+    gap: 0.5rem;
+}
+.shortcut-row kbd {
+    display: inline-flex; align-items: center; justify-content: center;
+    background: var(--bg-raised);
+    border: 1px solid var(--border-bright);
+    border-radius: var(--radius-sm);
+    padding: 0.125rem 0.375rem;
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    color: var(--text-primary);
+    min-width: 24px; min-height: 24px;
+    box-shadow: 0 1px 0 var(--border);
+}
+.shortcut-row span:last-child {
+    margin-left: auto;
+    color: var(--text-secondary);
+    text-align: right;
+}
+
 /* Ecosystem links */
 .ecosystem-links {
     display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.375rem;

--- a/src/views/chat.test.ts
+++ b/src/views/chat.test.ts
@@ -631,6 +631,105 @@ describe('chat view', () => {
     });
   });
 
+  // ── keyboard shortcuts help ──
+
+  describe('keyboard shortcuts help overlay', () => {
+    it('renders shortcuts button in the header', () => {
+      const html = renderChat();
+      expect(html).toContain('id="btn-shortcuts"');
+    });
+
+    it('renders shortcuts overlay hidden by default', () => {
+      renderIntoDOM(renderChat());
+      const overlay = document.getElementById('shortcuts-overlay');
+      expect(overlay).toBeTruthy();
+      expect(overlay!.style.display).toBe('none');
+    });
+
+    it('opens shortcuts overlay on button click', () => {
+      setupChat();
+      const overlay = document.getElementById('shortcuts-overlay')!;
+
+      document.getElementById('btn-shortcuts')!.click();
+
+      expect(overlay.style.display).toBe('');
+    });
+
+    it('closes shortcuts overlay on second button click (toggle)', () => {
+      setupChat();
+      const overlay = document.getElementById('shortcuts-overlay')!;
+
+      document.getElementById('btn-shortcuts')!.click();
+      document.getElementById('btn-shortcuts')!.click();
+
+      expect(overlay.style.display).toBe('none');
+    });
+
+    it('closes shortcuts overlay via close button', () => {
+      setupChat();
+
+      document.getElementById('btn-shortcuts')!.click();
+      document.getElementById('shortcuts-close')!.click();
+
+      expect(document.getElementById('shortcuts-overlay')!.style.display).toBe('none');
+    });
+
+    it('closes shortcuts overlay on Escape key', () => {
+      setupChat();
+      const overlay = document.getElementById('shortcuts-overlay')!;
+
+      document.getElementById('btn-shortcuts')!.click();
+      expect(overlay.style.display).toBe('');
+
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+      );
+
+      expect(overlay.style.display).toBe('none');
+    });
+
+    it('toggles shortcuts overlay on "?" key press', () => {
+      setupChat();
+      const overlay = document.getElementById('shortcuts-overlay')!;
+
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: '?', bubbles: true })
+      );
+      expect(overlay.style.display).toBe('');
+
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: '?', bubbles: true })
+      );
+      expect(overlay.style.display).toBe('none');
+    });
+
+    it('closes shortcuts overlay on click outside modal', () => {
+      setupChat();
+      const overlay = document.getElementById('shortcuts-overlay')!;
+
+      document.getElementById('btn-shortcuts')!.click();
+      expect(overlay.style.display).toBe('');
+
+      // Click on the overlay background (not the modal inside)
+      overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+      expect(overlay.style.display).toBe('none');
+    });
+
+    it('lists all shortcut groups', () => {
+      renderIntoDOM(renderChat());
+      const overlay = document.getElementById('shortcuts-overlay')!;
+
+      expect(overlay.textContent).toContain('Messages');
+      expect(overlay.textContent).toContain('Search');
+      expect(overlay.textContent).toContain('Navigation');
+      expect(overlay.textContent).toContain('Send message');
+      expect(overlay.textContent).toContain('New line');
+      expect(overlay.textContent).toContain('Open search');
+      expect(overlay.textContent).toContain('Close search');
+    });
+  });
+
   // ── cleanupChat ──
 
   describe('cleanupChat', () => {

--- a/src/views/chat.ts
+++ b/src/views/chat.ts
@@ -12,6 +12,8 @@ import { saveMessage, updateMessageStatus as dbUpdateStatus, loadMessages } from
 import { getDeviceName } from '../device-name.ts';
 import { processFile, createImagePreview, createFileDownload, formatFileSize, isAcceptedType } from '../file-handler.ts';
 
+/** Detect macOS for shortcut labels */
+const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
 /** How often to check agent online status and wallet balance (ms) */
 const STATUS_CHECK_INTERVAL_MS = 30_000;
 /** Max height for auto-resizing textarea (px) */
@@ -61,6 +63,7 @@ export function renderChat(): string {
           <span class="wallet-badge__addr">${walletAddr}</span>
         </div>
         <button id="btn-search" class="icon-btn" title="Search messages">&#x1F50D;</button>
+        <button id="btn-shortcuts" class="icon-btn" title="Keyboard shortcuts">?</button>
         <button id="btn-settings" class="icon-btn" title="Settings">&#x2699;</button>
       </div>
     </div>
@@ -106,6 +109,33 @@ export function renderChat(): string {
       <textarea id="chat-input" class="input-bar__field" rows="1"
         placeholder="Type a message..." autocomplete="off"></textarea>
       <button id="btn-send" class="input-bar__send" disabled>Send</button>
+    </div>
+
+    <div id="shortcuts-overlay" class="modal-overlay" style="display:none">
+      <div class="modal shortcuts-modal">
+        <div class="modal__title">Keyboard Shortcuts</div>
+        <div class="shortcuts-list">
+          <div class="shortcuts-group">
+            <div class="shortcuts-group__title">Messages</div>
+            <div class="shortcut-row"><kbd>Enter</kbd><span>Send message</span></div>
+            <div class="shortcut-row"><kbd>Shift</kbd> + <kbd>Enter</kbd><span>New line</span></div>
+          </div>
+          <div class="shortcuts-group">
+            <div class="shortcuts-group__title">Search</div>
+            <div class="shortcut-row"><kbd>${isMac ? 'Cmd' : 'Ctrl'}</kbd> + <kbd>F</kbd><span>Open search</span></div>
+            <div class="shortcut-row"><kbd>Escape</kbd><span>Close search</span></div>
+            <div class="shortcut-row"><kbd>Enter</kbd><span>Next match</span></div>
+            <div class="shortcut-row"><kbd>Shift</kbd> + <kbd>Enter</kbd><span>Previous match</span></div>
+          </div>
+          <div class="shortcuts-group">
+            <div class="shortcuts-group__title">Navigation</div>
+            <div class="shortcut-row"><kbd>?</kbd><span>Toggle this help</span></div>
+          </div>
+        </div>
+        <div class="modal__actions">
+          <button id="shortcuts-close" class="btn btn--secondary">Close</button>
+        </div>
+      </div>
     </div>
   `;
 }
@@ -630,6 +660,34 @@ export function bindChatEvents(): void {
   searchNext?.addEventListener('click', () => navigateSearch('next'));
   searchClose?.addEventListener('click', () => closeSearch());
 
+  // ── Shortcuts help overlay ──
+  const shortcutsOverlay = document.getElementById('shortcuts-overlay');
+  const btnShortcuts = document.getElementById('btn-shortcuts');
+  const shortcutsClose = document.getElementById('shortcuts-close');
+
+  function openShortcuts() {
+    if (shortcutsOverlay) shortcutsOverlay.style.display = '';
+  }
+
+  function closeShortcuts() {
+    if (shortcutsOverlay) shortcutsOverlay.style.display = 'none';
+  }
+
+  btnShortcuts?.addEventListener('click', () => {
+    if (shortcutsOverlay?.style.display === 'none') {
+      openShortcuts();
+    } else {
+      closeShortcuts();
+    }
+  });
+
+  shortcutsClose?.addEventListener('click', closeShortcuts);
+
+  // Close on click outside the modal
+  shortcutsOverlay?.addEventListener('click', (e) => {
+    if (e.target === shortcutsOverlay) closeShortcuts();
+  });
+
   // Global keyboard shortcut: Ctrl/Cmd+F opens search
   const handleGlobalKeydown = (e: KeyboardEvent) => {
     if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
@@ -639,6 +697,24 @@ export function bindChatEvents(): void {
     if (e.key === 'Escape' && searchOpen) {
       closeSearch();
     }
+    // "?" key opens shortcuts help (when not typing in input/search)
+    if (
+      e.key === '?' &&
+      !e.ctrlKey && !e.metaKey && !e.altKey &&
+      document.activeElement !== inputEl &&
+      document.activeElement !== searchInput
+    ) {
+      e.preventDefault();
+      if (shortcutsOverlay?.style.display === 'none') {
+        openShortcuts();
+      } else {
+        closeShortcuts();
+      }
+    }
+    // Escape closes shortcuts overlay
+    if (e.key === 'Escape' && shortcutsOverlay?.style.display !== 'none') {
+      closeShortcuts();
+    }
   };
   document.addEventListener('keydown', handleGlobalKeydown);
 
@@ -647,6 +723,7 @@ export function bindChatEvents(): void {
     clearInterval(statusTimer);
     document.removeEventListener('keydown', handleGlobalKeydown);
     closeSearch();
+    closeShortcuts();
     clearPendingAttachment();
   };
 }


### PR DESCRIPTION
## Summary
- Adds a "?" button in the chat header that opens a keyboard shortcuts help overlay
- Lists all available shortcuts organized by category (Messages, Search, Navigation)
- Overlay can be toggled via the "?" key, button click, or dismissed with Escape / clicking outside
- Detects macOS vs other platforms to show correct modifier key (Cmd vs Ctrl)
- 9 new unit tests covering overlay rendering, open/close, keyboard toggle, and click-outside dismissal

Closes #22

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 266 unit tests pass (9 new)
- [ ] Manual: verify overlay opens on "?" button click
- [ ] Manual: verify overlay opens/closes on "?" key press
- [ ] Manual: verify Escape and click-outside close the overlay
- [ ] Manual: verify correct Cmd/Ctrl label on macOS vs other platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)