### PR TITLE
fix: patch serialize-javascript RCE via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4833,14 +4833,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "dev": true,
@@ -4990,25 +4982,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "dev": true,
@@ -5060,11 +5033,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-function-length": {

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "@corvidlabs/ts-algochat": "^0.3.0",
     "algosdk": "^3.5.2",
     "html5-qrcode": "^2.3.8"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.0.3"
   }
 }


### PR DESCRIPTION
## Summary
- Adds npm `overrides` to force `serialize-javascript@^7.0.3`, fixing GHSA-5c6j-r48x-rmvq (RCE via RegExp.flags and Date.prototype.toISOString)
- The vulnerability is in a transitive dependency chain: `vite-plugin-pwa → workbox-build → @rollup/plugin-terser → serialize-javascript`
- Override is scoped to the specific vulnerable package until upstream updates

Closes #28

## Test plan
- [x] npm audit shows 0 vulnerabilities
- [x] tsc --noEmit passes
- [x] vitest run passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)