### PR TITLE
feat: add date separator dividers between messages

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -788,6 +788,13 @@ mark.search-highlight {
     border-top: 1px solid var(--border);
 }
 
+/* Date separator in chat */
+.date-separator {
+    font-size: 0.75rem;
+    font-family: var(--font-mono);
+    user-select: none;
+}
+
 /* Toast notifications */
 .toast-container {
     position: fixed; top: calc(0.75rem + env(safe-area-inset-top)); right: calc(0.75rem + env(safe-area-inset-right));

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { escapeHtml, bufferToBase64, base64ToBuffer, shortenAddress, formatTime } from './utils.ts';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { escapeHtml, bufferToBase64, base64ToBuffer, shortenAddress, formatTime, formatDateLabel } from './utils.ts';
 
 describe('escapeHtml', () => {
   it('escapes ampersands', () => {
@@ -93,5 +93,53 @@ describe('formatTime', () => {
   it('formats midnight', () => {
     const d = new Date(2026, 0, 15, 0, 0);
     expect(formatTime(d)).toBe('00:00');
+  });
+});
+
+describe('formatDateLabel', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns "Today" for the current date', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 1, 28, 15, 0));
+    expect(formatDateLabel(new Date(2026, 1, 28, 9, 30))).toBe('Today');
+  });
+
+  it('returns "Yesterday" for the previous day', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 1, 28, 15, 0));
+    expect(formatDateLabel(new Date(2026, 1, 27, 22, 0))).toBe('Yesterday');
+  });
+
+  it('returns short date for dates within the current year', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 1, 28, 15, 0));
+    expect(formatDateLabel(new Date(2026, 1, 25, 10, 0))).toBe('Feb 25');
+  });
+
+  it('returns date with year for dates in a previous year', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 1, 28, 15, 0));
+    expect(formatDateLabel(new Date(2025, 11, 31, 10, 0))).toBe('Dec 31, 2025');
+  });
+
+  it('returns short date for January 1 of the current year', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 15, 12, 0));
+    expect(formatDateLabel(new Date(2026, 0, 1, 0, 0))).toBe('Jan 1');
+  });
+
+  it('handles "Today" at midnight boundary', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 1, 28, 0, 1));
+    expect(formatDateLabel(new Date(2026, 1, 28, 0, 0))).toBe('Today');
+  });
+
+  it('handles "Yesterday" at midnight boundary', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 1, 28, 0, 1));
+    expect(formatDateLabel(new Date(2026, 1, 27, 23, 59))).toBe('Yesterday');
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,6 +48,34 @@ export function base64ToBuffer(b64: string): Uint8Array {
 }
 
 /**
+ * Format a Date to a human-readable date label for message grouping.
+ * Returns "Today", "Yesterday", or a short date like "Feb 25" (current year)
+ * or "Feb 25, 2025" (previous years).
+ */
+export function formatDateLabel(date: Date): string {
+  const d = date instanceof Date ? date : new Date(date);
+  const now = new Date();
+
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const startOfDay = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+
+  const diffMs = startOfToday.getTime() - startOfDay.getTime();
+  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  const month = months[d.getMonth()]!;
+  const day = d.getDate();
+
+  if (d.getFullYear() === now.getFullYear()) {
+    return `${month} ${day}`;
+  }
+  return `${month} ${day}, ${d.getFullYear()}`;
+}
+
+/**
  * Shorten an Algorand address for display
  */
 export function shortenAddress(

--- a/src/views/chat.test.ts
+++ b/src/views/chat.test.ts
@@ -98,6 +98,7 @@ vi.mock('../utils.ts', () => ({
   escapeHtml: (s: string) => s,
   shortenAddress: (s: string, a = 6, b = 4) => `${s.slice(0, a)}...${s.slice(-b)}`,
   formatTime: () => '12:00',
+  formatDateLabel: () => 'Today',
 }));
 vi.mock('../file-handler.ts', () => ({
   processFile: vi.fn(),

--- a/src/views/chat.ts
+++ b/src/views/chat.ts
@@ -7,7 +7,7 @@ import { getAccount } from '../wallet.ts';
 import { renderMarkdown } from '../markdown.ts';
 import { showToast } from '../toast.ts';
 import type { Attachment, ChatMessage } from '../types.ts';
-import { escapeHtml, shortenAddress, formatTime } from '../utils.ts';
+import { escapeHtml, shortenAddress, formatTime, formatDateLabel } from '../utils.ts';
 import { saveMessage, updateMessageStatus as dbUpdateStatus, loadMessages } from '../db.ts';
 import { getDeviceName } from '../device-name.ts';
 import { processFile, createImagePreview, createFileDownload, formatFileSize, isAcceptedType } from '../file-handler.ts';
@@ -35,6 +35,9 @@ let searchQuery = '';
 let searchMatches: HTMLElement[] = [];
 let searchCurrentIdx = -1;
 let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+/* ── Date separator tracking ── */
+let lastMessageDate: string | null = null;
 
 /* ── Pending attachment state ── */
 let pendingAttachment: Attachment | null = null;
@@ -736,6 +739,17 @@ function appendMessage(msg: ChatMessage): void {
     hideThinking();
   }
 
+  // Insert date separator if the day changed
+  const msgDate = msg.timestamp instanceof Date ? msg.timestamp : new Date(msg.timestamp);
+  const dayKey = `${msgDate.getFullYear()}-${msgDate.getMonth()}-${msgDate.getDate()}`;
+  if (dayKey !== lastMessageDate) {
+    lastMessageDate = dayKey;
+    const sep = document.createElement('div');
+    sep.className = 'divider date-separator';
+    sep.textContent = formatDateLabel(msgDate);
+    outputEl.appendChild(sep);
+  }
+
   const div = document.createElement('div');
   div.className = `msg msg--${msg.direction === 'sent' ? 'outbound' : 'inbound'}`;
   div.id = `msg-${msg.id}`;
@@ -859,6 +873,7 @@ export function cleanupChat(): void {
 
   pendingAttachment = null;
   pendingCaption = null;
+  lastMessageDate = null;
   outputEl = null;
   inputEl = null;
 }


### PR DESCRIPTION
## Summary
- Adds date separator headers between messages from different days in the chat view
- Shows "Today", "Yesterday", or formatted date (e.g., "Feb 25") between message groups
- Uses existing divider styling for visual consistency
- Includes unit tests for date formatting

Closes #26

## Test plan
- [x] tsc --noEmit passes
- [x] vitest run passes (including new tests)
- [x] Date separators appear between messages from different days
- [x] "Today" and "Yesterday" labels work correctly
- [x] Older dates show formatted date string

🤖 Generated with [Claude Code](https://claude.com/claude-code)