### PR TITLE
chore: enable noUnusedLocals and noUnusedParameters in tsconfig

### DIFF
--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -2,7 +2,7 @@
  * Tests for IndexedDB message persistence layer
  * Uses fake-indexeddb to provide an in-memory IndexedDB implementation
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import 'fake-indexeddb/auto';
 import {
   saveMessage,

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@
  */
 import { store } from './store.ts';
 import { hasStoredWallet } from './wallet.ts';
-import { loadConnection } from './qr-scanner.ts';
+
 import { startIdleLock, stopIdleLock } from './idle-lock.ts';
 import { registerServiceWorker } from './pwa.ts';
 import type { AppView } from './types.ts';

--- a/src/messaging.test.ts
+++ b/src/messaging.test.ts
@@ -2,7 +2,7 @@
  * Tests for PSK state management in MessagingService
  * Verifies fingerprint-based state reset when PSK changes
  */
-import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { describe, test, expect } from 'vitest';
 
 // Simulate the messaging service's PSK fingerprint logic (same as in messaging.ts)
 function pskFingerprint(psk: Uint8Array): string {

--- a/src/pwa.ts
+++ b/src/pwa.ts
@@ -16,7 +16,7 @@ export async function registerServiceWorker(): Promise<void> {
 
     const updateSW = registerSW({
       immediate: true,
-      onRegisteredSW(swUrl, registration) {
+      onRegisteredSW(_swUrl, registration) {
         // Check for updates every 30 minutes
         if (registration) {
           setInterval(() => {

--- a/src/qr-scanner.test.ts
+++ b/src/qr-scanner.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { bufferToBase64 } from './utils.ts';
 import { stubLocalStorage } from './test-utils.ts';
 
-const { store } = stubLocalStorage();
+stubLocalStorage();
 
 /** Encode Uint8Array to base64url (no padding) — mirrors ts-algochat encoding */
 function toBase64Url(data: Uint8Array): string {

--- a/src/views/settings.ts
+++ b/src/views/settings.ts
@@ -2,8 +2,8 @@
  * Settings view - Wallet management, agent info, disconnect
  */
 import { store } from '../store.ts';
-import { getAccount, exportMnemonic, deleteWallet, lockWallet } from '../wallet.ts';
-import { clearConnection, loadConnection } from '../qr-scanner.ts';
+import { exportMnemonic, deleteWallet, lockWallet } from '../wallet.ts';
+import { clearConnection } from '../qr-scanner.ts';
 import { messaging } from '../messaging.ts';
 import { showToast } from '../toast.ts';
 import { escapeHtml } from '../utils.ts';

--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -2,7 +2,7 @@
  * Tests for wallet management: encryption, decryption, storage, and lifecycle
  * Covers the critical security path: PBKDF2 key derivation + AES-GCM encrypt/decrypt
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 
 import { bufferToBase64, base64ToBuffer } from './utils.ts';
 import type { StoredWallet } from './types.ts';

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -2,7 +2,7 @@
  * Wallet management with encrypted storage
  * Uses Web Crypto API: AES-GCM + PBKDF2
  */
-import algosdk from 'algosdk';
+
 import {
   createChatAccountFromMnemonic,
   createRandomChatAccount,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,8 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "noPropertyAccessFromIndexSignature": false
   },
   "include": ["src/**/*.ts"]


### PR DESCRIPTION
## Summary
- Enables `noUnusedLocals` and `noUnusedParameters` in `tsconfig.json` to catch dead code at compile time
- Removes unused imports: `algosdk` (wallet.ts), `getAccount`/`loadConnection` (settings.ts), `loadConnection` (main.ts), `beforeEach`/`vi` (test files)
- Prefixes unused callback parameter `swUrl` → `_swUrl` in pwa.ts
- Removes unused destructured `store` variable in qr-scanner.test.ts

## Test plan
- [x] `npx tsc --noEmit` compiles cleanly with zero errors
- [x] All 273 tests pass across 13 test suites
- [ ] CI pipeline passes

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)