### PR TITLE
fix: prevent duplicate user messages (#39)

### DIFF
--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -546,9 +546,6 @@ export class MessagingService {
       this.lastRound = maxRound;
       this.saveLastRound();
       this.savePSKState();
-      // Clear processed txids — minRound filtering prevents re-processing old transactions
-      this.processedTxids.clear();
-      this.saveProcessedTxids();
     }
 
     // Also poll for messages sent from our wallet by other devices

--- a/src/store.ts
+++ b/src/store.ts
@@ -102,10 +102,12 @@ class Store {
     this.notify();
   }
 
-  addMessage(message: ChatMessage) {
-    // Deduplicate by id
-    const existing = this.state.chat.messages.find((m) => m.id === message.id);
-    if (existing) return;
+  addMessage(message: ChatMessage): boolean {
+    // Deduplicate by id or by txid (prevents optimistic + polled duplicates)
+    const existing = this.state.chat.messages.find(
+      (m) => m.id === message.id || (message.txid && m.txid === message.txid)
+    );
+    if (existing) return false;
 
     this.state = {
       ...this.state,
@@ -117,6 +119,7 @@ class Store {
       },
     };
     this.notify();
+    return true;
   }
 
   updateMessageStatus(id: string, status: ChatMessage['status'], txid?: string) {

--- a/src/views/chat.test.ts
+++ b/src/views/chat.test.ts
@@ -50,7 +50,7 @@ const {
       setAgentConnection: vi.fn(),
       setAgentOnline: vi.fn(),
       setBalance: vi.fn(),
-      addMessage: vi.fn(),
+      addMessage: vi.fn().mockReturnValue(true),
       updateMessageStatus: vi.fn(),
       setPolling: vi.fn(),
       setSending: vi.fn(),

--- a/src/views/chat.ts
+++ b/src/views/chat.ts
@@ -183,7 +183,8 @@ export function bindChatEvents(): void {
 
   // Subscribe to incoming messages
   unsubMessages = messaging.onMessage((msg: ChatMessage) => {
-    store.addMessage(msg);
+    // addMessage returns false if deduplicated (e.g. optimistic send already exists)
+    if (!store.addMessage(msg)) return;
     appendMessage(msg);
     // Persist to IndexedDB
     saveMessage(msg, connection.address);


### PR DESCRIPTION
## Summary

- **Remove premature `processedTxids.clear()`** in `messaging.ts` — the set was being wiped whenever `lastRound` advanced, causing locally-sent txids to be forgotten before `pollSentMessages()` could check them on the next poll cycle.
- **Deduplicate by `txid` in `store.addMessage()`** — the optimistic message uses a temp id (`temp-{timestamp}`) while the polled copy uses the blockchain txid, so id-only dedup missed the match. Now checks both `id` and `txid`.
- **Skip rendering on dedup** — `addMessage()` now returns `boolean`; the `onMessage` callback in `chat.ts` skips `appendMessage` and `saveMessage` when the store rejects a duplicate.

## Root cause

When a user sends a message:
1. Optimistic message added with `id: "temp-123"`, later updated with `txid: "ABC"`
2. `processedTxids` tracks `"ABC"` to prevent re-processing
3. **Bug**: `processedTxids.clear()` fires when `lastRound` advances, deleting `"ABC"`
4. Next `pollSentMessages()` discovers txn `"ABC"` on-chain, doesn't find it in the cleared set
5. Emits it as a new message with `id: "ABC"`
6. **Bug**: Store dedup only checks `id` — `"temp-123" !== "ABC"` → duplicate added

## Test plan

- [x] All 315 existing tests pass
- [ ] Manual test: send a message, verify only one copy appears after poll cycle
- [ ] Verify cross-device sync still works (messages from other devices still appear)

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)