### PR TITLE
test: add toast, chat-messages, and chat-search coverage (+69)

### DIFF
--- a/src/toast.test.ts
+++ b/src/toast.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for toast notification system
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { showToast } from './toast.ts';
+
+describe('showToast', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('creates a toast container on first call', () => {
+    showToast('hello');
+    const container = document.querySelector('.toast-container');
+    expect(container).not.toBeNull();
+    expect(container?.getAttribute('role')).toBe('status');
+    expect(container?.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('reuses the same container on subsequent calls', () => {
+    showToast('first');
+    showToast('second');
+    const containers = document.querySelectorAll('.toast-container');
+    expect(containers.length).toBe(1);
+    expect(containers[0]!.children.length).toBe(2);
+  });
+
+  it('creates a toast element with correct class and text', () => {
+    showToast('Test message');
+    const toast = document.querySelector('.toast');
+    expect(toast).not.toBeNull();
+    expect(toast?.textContent).toBe('Test message');
+    expect(toast?.classList.contains('toast--info')).toBe(true);
+  });
+
+  it('applies success type class', () => {
+    showToast('Saved!', 'success');
+    const toast = document.querySelector('.toast--success');
+    expect(toast).not.toBeNull();
+    expect(toast?.textContent).toBe('Saved!');
+  });
+
+  it('applies error type class and uses assertive aria-live', () => {
+    showToast('Failed!', 'error');
+    const toast = document.querySelector('.toast--error');
+    expect(toast).not.toBeNull();
+    const container = document.querySelector('.toast-container');
+    expect(container?.getAttribute('role')).toBe('alert');
+    expect(container?.getAttribute('aria-live')).toBe('assertive');
+  });
+
+  it('restores polite aria-live for non-error toasts after error', () => {
+    showToast('Error!', 'error');
+    showToast('Info!', 'info');
+    const container = document.querySelector('.toast-container');
+    expect(container?.getAttribute('role')).toBe('status');
+    expect(container?.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('removes toast after the specified duration', () => {
+    showToast('Temporary', 'info', 2000);
+    expect(document.querySelector('.toast')).not.toBeNull();
+
+    // Advance past the fade-out trigger
+    vi.advanceTimersByTime(2000);
+    // Toast should have opacity/transform set but still in DOM during transition
+    const toast = document.querySelector('.toast') as HTMLElement;
+    expect(toast?.style.opacity).toBe('0');
+    expect(toast?.style.transform).toBe('translateX(100%)');
+
+    // Advance past the removal transition (300ms)
+    vi.advanceTimersByTime(300);
+    expect(document.querySelector('.toast')).toBeNull();
+  });
+
+  it('uses default 4000ms duration when not specified', () => {
+    showToast('Default duration');
+    expect(document.querySelector('.toast')).not.toBeNull();
+
+    vi.advanceTimersByTime(3999);
+    expect(document.querySelector('.toast')?.textContent).toBe('Default duration');
+
+    vi.advanceTimersByTime(1);
+    const toast = document.querySelector('.toast') as HTMLElement;
+    expect(toast?.style.opacity).toBe('0');
+  });
+
+  it('handles multiple toasts with different durations', () => {
+    showToast('First', 'info', 1000);
+    showToast('Second', 'info', 3000);
+
+    const container = document.querySelector('.toast-container')!;
+    expect(container.children.length).toBe(2);
+
+    // First toast fades out
+    vi.advanceTimersByTime(1000);
+    vi.advanceTimersByTime(300);
+    expect(container.children.length).toBe(1);
+    expect(container.children[0]?.textContent).toBe('Second');
+
+    // Second toast fades out
+    vi.advanceTimersByTime(2000);
+    vi.advanceTimersByTime(300);
+    expect(container.children.length).toBe(0);
+  });
+
+  it('sets aria-atomic to false on container', () => {
+    showToast('test');
+    const container = document.querySelector('.toast-container');
+    expect(container?.getAttribute('aria-atomic')).toBe('false');
+  });
+});

--- a/src/toast.ts
+++ b/src/toast.ts
@@ -6,7 +6,7 @@
 let container: HTMLElement | null = null;
 
 function getContainer(): HTMLElement {
-  if (!container) {
+  if (!container || !container.isConnected) {
     container = document.createElement('div');
     container.className = 'toast-container';
     container.setAttribute('role', 'status');

--- a/src/views/chat-messages.test.ts
+++ b/src/views/chat-messages.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for chat-messages — message rendering, date separators, status updates, thinking indicator
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ChatMessage } from '../types.ts';
+
+// jsdom does not implement scrollIntoView
+Element.prototype.scrollIntoView = vi.fn();
+
+// ── Hoisted mocks ──
+const { mockStore, mockMessaging, mockToast, mockDb, mockDeviceName, mockFileHandler } = vi.hoisted(() => ({
+  mockStore: {
+    getState: vi.fn(() => ({
+      chat: { messages: [] },
+    })),
+    updateMessageStatus: vi.fn(),
+  },
+  mockMessaging: {
+    sendMessage: vi.fn().mockResolvedValue('TXID_RETRY'),
+  },
+  mockToast: {
+    showToast: vi.fn(),
+  },
+  mockDb: {
+    updateMessageStatus: vi.fn(),
+  },
+  mockDeviceName: {
+    getDeviceName: vi.fn((): string | null => null),
+  },
+  mockFileHandler: {
+    createImagePreview: vi.fn(() => document.createElement('div')),
+    createFileDownload: vi.fn(() => document.createElement('div')),
+  },
+}));
+
+vi.mock('../store.ts', () => ({ store: mockStore }));
+vi.mock('../messaging.ts', () => ({ messaging: mockMessaging }));
+vi.mock('../toast.ts', () => mockToast);
+vi.mock('../db.ts', () => mockDb);
+vi.mock('../device-name.ts', () => mockDeviceName);
+vi.mock('../markdown.ts', () => ({
+  renderMarkdown: vi.fn((text: string) => text),
+}));
+vi.mock('../utils.ts', () => ({
+  escapeHtml: (s: string) => s,
+  formatTime: () => '12:00',
+  formatDateLabel: () => 'Today',
+}));
+vi.mock('../file-handler.ts', () => mockFileHandler);
+
+import {
+  appendMessage,
+  updateMessageEl,
+  showThinking,
+  hideThinking,
+  setOutputEl,
+  resetMessageState,
+} from './chat-messages.ts';
+
+function makeMsg(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: `msg-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    content: 'Hello world',
+    direction: 'sent',
+    timestamp: new Date('2026-03-05T12:00:00Z'),
+    status: 'confirmed',
+    ...overrides,
+  };
+}
+
+describe('chat-messages', () => {
+  let outputEl: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="output"></div>';
+    outputEl = document.getElementById('output')!;
+    setOutputEl(outputEl);
+  });
+
+  afterEach(() => {
+    resetMessageState();
+  });
+
+  describe('appendMessage', () => {
+    it('renders a sent message with [you] prompt', () => {
+      appendMessage(makeMsg({ content: 'Hi there' }));
+      const prompt = outputEl.querySelector('.msg__prompt');
+      expect(prompt?.textContent).toContain('[you]');
+      const text = outputEl.querySelector('.msg__text');
+      expect(text?.textContent).toContain('Hi there');
+    });
+
+    it('renders a received message with [agent] prompt', () => {
+      appendMessage(makeMsg({ direction: 'received', content: 'Response' }));
+      const prompt = outputEl.querySelector('.msg__prompt');
+      expect(prompt?.textContent).toContain('[agent]');
+    });
+
+    it('renders sent message with device name when available', () => {
+      appendMessage(makeMsg({ deviceName: 'laptop' }));
+      const prompt = outputEl.querySelector('.msg__prompt');
+      expect(prompt?.textContent).toContain('[you@laptop]');
+    });
+
+    it('falls back to global device name for sent messages without deviceName', () => {
+      mockDeviceName.getDeviceName.mockReturnValue('desktop');
+      appendMessage(makeMsg({ deviceName: undefined }));
+      const prompt = outputEl.querySelector('.msg__prompt');
+      expect(prompt?.textContent).toContain('[you@desktop]');
+      mockDeviceName.getDeviceName.mockReturnValue(null);
+    });
+
+    it('applies outbound class for sent messages', () => {
+      appendMessage(makeMsg({ id: 'test-1' }));
+      const el = document.getElementById('msg-test-1');
+      expect(el?.classList.contains('msg--outbound')).toBe(true);
+    });
+
+    it('applies inbound class for received messages', () => {
+      appendMessage(makeMsg({ id: 'test-2', direction: 'received' }));
+      const el = document.getElementById('msg-test-2');
+      expect(el?.classList.contains('msg--inbound')).toBe(true);
+    });
+
+    it('shows sending status badge', () => {
+      appendMessage(makeMsg({ status: 'sending' }));
+      const status = outputEl.querySelector('.msg__status');
+      expect(status?.textContent).toContain('sending');
+      expect(status?.getAttribute('data-status')).toBe('sending');
+    });
+
+    it('shows failed status with retry button', () => {
+      appendMessage(makeMsg({ status: 'failed' }));
+      const status = outputEl.querySelector('.msg__status');
+      expect(status?.getAttribute('data-status')).toBe('failed');
+      const retryBtn = outputEl.querySelector('.msg__retry');
+      expect(retryBtn).not.toBeNull();
+    });
+
+    it('shows no status badge for confirmed messages', () => {
+      appendMessage(makeMsg({ status: 'confirmed' }));
+      const status = outputEl.querySelector('.msg__status');
+      expect(status).toBeNull();
+    });
+
+    it('renders time stamp', () => {
+      appendMessage(makeMsg());
+      const time = outputEl.querySelector('.msg__time');
+      expect(time?.textContent).toBe('12:00');
+    });
+
+    it('renders tx link when txid is present', () => {
+      appendMessage(makeMsg({ txid: 'SOMETXID' }));
+      const link = outputEl.querySelector('.msg__txlink') as HTMLAnchorElement;
+      expect(link).not.toBeNull();
+      expect(link?.href).toContain('SOMETXID');
+      expect(link?.target).toBe('_blank');
+      expect(link?.rel).toContain('noopener');
+    });
+
+    it('does not render tx link when no txid', () => {
+      appendMessage(makeMsg({ txid: undefined }));
+      const link = outputEl.querySelector('.msg__txlink');
+      expect(link).toBeNull();
+    });
+
+    it('renders copy button', () => {
+      appendMessage(makeMsg());
+      const copyBtn = outputEl.querySelector('.msg__copy');
+      expect(copyBtn).not.toBeNull();
+    });
+
+    it('inserts date separator on first message', () => {
+      appendMessage(makeMsg());
+      const sep = outputEl.querySelector('.date-separator');
+      expect(sep).not.toBeNull();
+      expect(sep?.textContent).toBe('Today');
+    });
+
+    it('does not duplicate date separator for same-day messages', () => {
+      appendMessage(makeMsg({ id: 'a' }));
+      appendMessage(makeMsg({ id: 'b' }));
+      const seps = outputEl.querySelectorAll('.date-separator');
+      expect(seps.length).toBe(1);
+    });
+
+    it('inserts new date separator when day changes', () => {
+      appendMessage(makeMsg({ id: 'a', timestamp: new Date('2026-03-04T10:00:00Z') }));
+      appendMessage(makeMsg({ id: 'b', timestamp: new Date('2026-03-05T10:00:00Z') }));
+      const seps = outputEl.querySelectorAll('.date-separator');
+      expect(seps.length).toBe(2);
+    });
+
+    it('removes thinking indicator when receiving a message', () => {
+      showThinking();
+      expect(document.getElementById('thinking-indicator')).not.toBeNull();
+      appendMessage(makeMsg({ direction: 'received' }));
+      expect(document.getElementById('thinking-indicator')).toBeNull();
+    });
+
+    it('does not remove thinking indicator for sent messages', () => {
+      showThinking();
+      appendMessage(makeMsg({ direction: 'sent' }));
+      expect(document.getElementById('thinking-indicator')).not.toBeNull();
+    });
+
+    it('does nothing when outputEl is null', () => {
+      setOutputEl(null);
+      appendMessage(makeMsg());
+      // No crash, no DOM changes
+      expect(outputEl.children.length).toBe(0);
+    });
+
+    it('scrolls to bottom after appending', () => {
+      // scrollTop setter is available in jsdom
+      appendMessage(makeMsg());
+      // outputEl.scrollTop should be set to scrollHeight
+      expect(outputEl.children.length).toBeGreaterThan(0);
+    });
+
+    it('renders image attachment', () => {
+      appendMessage(makeMsg({
+        attachment: { type: 'image', mimeType: 'image/png', fileName: 'pic.png', size: 1024 },
+      }));
+      expect(mockFileHandler.createImagePreview).toHaveBeenCalled();
+    });
+
+    it('renders file attachment', () => {
+      appendMessage(makeMsg({
+        attachment: { type: 'file', mimeType: 'text/plain', fileName: 'readme.txt', size: 512 },
+      }));
+      expect(mockFileHandler.createFileDownload).toHaveBeenCalled();
+    });
+  });
+
+  describe('updateMessageEl', () => {
+    it('removes status badge when confirmed', () => {
+      appendMessage(makeMsg({ id: 'upd-1', status: 'sending' }));
+      expect(document.querySelector('.msg__status')).not.toBeNull();
+      updateMessageEl('upd-1', 'confirmed');
+      expect(document.querySelector('.msg__status')).toBeNull();
+    });
+
+    it('updates status badge to failed', () => {
+      appendMessage(makeMsg({ id: 'upd-2', status: 'sending' }));
+      updateMessageEl('upd-2', 'failed');
+      const status = document.querySelector('.msg__status');
+      expect(status?.getAttribute('data-status')).toBe('failed');
+      expect(status?.textContent).toContain('failed');
+    });
+
+    it('handles non-existent message gracefully', () => {
+      // Should not throw
+      updateMessageEl('nonexistent', 'confirmed');
+    });
+  });
+
+  describe('showThinking / hideThinking', () => {
+    it('shows thinking indicator with ARIA attributes', () => {
+      showThinking();
+      const indicator = document.getElementById('thinking-indicator');
+      expect(indicator).not.toBeNull();
+      expect(indicator?.getAttribute('role')).toBe('status');
+      expect(indicator?.getAttribute('aria-live')).toBe('polite');
+      expect(indicator?.textContent).toContain('Agent is thinking');
+    });
+
+    it('removes existing indicator before showing new one', () => {
+      showThinking();
+      showThinking();
+      const indicators = outputEl.querySelectorAll('#thinking-indicator');
+      expect(indicators.length).toBe(1);
+    });
+
+    it('hideThinking removes the indicator', () => {
+      showThinking();
+      hideThinking();
+      expect(document.getElementById('thinking-indicator')).toBeNull();
+    });
+
+    it('hideThinking does nothing when no indicator exists', () => {
+      // Should not throw
+      hideThinking();
+    });
+
+    it('showThinking does nothing when outputEl is null', () => {
+      setOutputEl(null);
+      showThinking();
+      expect(document.getElementById('thinking-indicator')).toBeNull();
+    });
+  });
+
+  describe('retry button', () => {
+    it('retries sending on click and shows success toast', async () => {
+      const msg = makeMsg({ id: 'retry-1', status: 'failed', content: 'retry me' });
+      appendMessage(msg);
+      const retryBtn = document.querySelector('.msg__retry') as HTMLElement;
+      expect(retryBtn).not.toBeNull();
+
+      retryBtn.click();
+      // Wait for async handler
+      await vi.waitFor(() => {
+        expect(mockMessaging.sendMessage).toHaveBeenCalledWith('retry me', undefined);
+      });
+      expect(mockStore.updateMessageStatus).toHaveBeenCalledWith('retry-1', 'confirmed', 'TXID_RETRY');
+      expect(mockToast.showToast).toHaveBeenCalledWith('Message resent', 'success');
+    });
+
+    it('shows error toast when retry fails', async () => {
+      mockMessaging.sendMessage.mockRejectedValueOnce(new Error('Network error'));
+      const msg = makeMsg({ id: 'retry-2', status: 'failed', content: 'fail me' });
+      appendMessage(msg);
+      const retryBtn = document.querySelector('.msg__retry') as HTMLElement;
+
+      retryBtn.click();
+      await vi.waitFor(() => {
+        expect(mockToast.showToast).toHaveBeenCalledWith('Retry failed: Network error', 'error');
+      });
+    });
+  });
+
+  describe('resetMessageState', () => {
+    it('clears module state', () => {
+      appendMessage(makeMsg());
+      resetMessageState();
+      // After reset, appending should do nothing (outputEl is null)
+      const el = document.createElement('div');
+      document.body.appendChild(el);
+      // outputEl was reset so appendMessage is a no-op
+      const before = el.children.length;
+      appendMessage(makeMsg());
+      expect(el.children.length).toBe(before);
+    });
+  });
+});

--- a/src/views/chat-search.test.ts
+++ b/src/views/chat-search.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Tests for chat-search — search bar UI, highlighting, and match navigation
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ChatMessage } from '../types.ts';
+
+// jsdom does not implement scrollIntoView
+Element.prototype.scrollIntoView = vi.fn();
+
+// ── Hoisted mocks ──
+const { mockStore } = vi.hoisted(() => {
+  const messages: ChatMessage[] = [];
+  return {
+    mockStore: {
+      getState: vi.fn(() => ({
+        chat: { messages },
+      })),
+      _setMessages(msgs: ChatMessage[]) {
+        messages.length = 0;
+        messages.push(...msgs);
+      },
+    },
+  };
+});
+
+vi.mock('../store.ts', () => ({ store: mockStore }));
+
+import {
+  isSearchOpen,
+  bindSearchEvents,
+  resetSearchState,
+} from './chat-search.ts';
+
+function makeMsg(id: string, content: string): ChatMessage {
+  return {
+    id,
+    content,
+    direction: 'sent',
+    timestamp: new Date('2026-03-05T12:00:00Z'),
+    status: 'confirmed',
+  };
+}
+
+/** Set up the full search bar HTML and bind events */
+function setupSearchDOM(messages: ChatMessage[] = []): HTMLElement {
+  mockStore._setMessages(messages);
+
+  document.body.innerHTML = `
+    <button id="btn-search" aria-expanded="false">Search</button>
+    <div id="search-bar" style="display: none;">
+      <input id="search-input" type="text" />
+      <span id="search-count"></span>
+      <button id="search-prev" disabled>Prev</button>
+      <button id="search-next" disabled>Next</button>
+      <button id="search-close">Close</button>
+    </div>
+    <div id="output">
+      ${messages.map((m) => `
+        <div class="msg" id="msg-${m.id}">
+          <span class="msg__time">12:00</span>
+          <span class="msg__prompt">[you]</span>
+          <span class="msg__text">${m.content}</span>
+          <button class="msg__copy">Copy</button>
+        </div>
+      `).join('')}
+    </div>
+  `;
+
+  const outputEl = document.getElementById('output');
+  bindSearchEvents(outputEl);
+  return outputEl!;
+}
+
+describe('chat-search', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    resetSearchState();
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  describe('open/close search', () => {
+    it('starts with search closed', () => {
+      setupSearchDOM();
+      expect(isSearchOpen()).toBe(false);
+    });
+
+    it('opens search bar on button click', () => {
+      setupSearchDOM();
+      const btn = document.getElementById('btn-search')!;
+      btn.click();
+      expect(isSearchOpen()).toBe(true);
+      expect(document.getElementById('search-bar')?.style.display).toBe('');
+      expect(btn.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('focuses search input when opened', () => {
+      setupSearchDOM();
+      const input = document.getElementById('search-input') as HTMLInputElement;
+      const focusSpy = vi.spyOn(input, 'focus');
+      document.getElementById('btn-search')!.click();
+      expect(focusSpy).toHaveBeenCalled();
+    });
+
+    it('closes search bar on close button click', () => {
+      setupSearchDOM();
+      document.getElementById('btn-search')!.click();
+      expect(isSearchOpen()).toBe(true);
+      document.getElementById('search-close')!.click();
+      expect(isSearchOpen()).toBe(false);
+      expect(document.getElementById('search-bar')?.style.display).toBe('none');
+    });
+
+    it('toggles search bar on search button click', () => {
+      setupSearchDOM();
+      const btn = document.getElementById('btn-search')!;
+      btn.click();
+      expect(isSearchOpen()).toBe(true);
+      btn.click();
+      expect(isSearchOpen()).toBe(false);
+    });
+
+    it('sets aria-expanded to false when closed', () => {
+      setupSearchDOM();
+      const btn = document.getElementById('btn-search')!;
+      btn.click();
+      document.getElementById('search-close')!.click();
+      expect(btn.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('returns focus to search button on close', () => {
+      setupSearchDOM();
+      const btn = document.getElementById('btn-search')!;
+      const focusSpy = vi.spyOn(btn, 'focus');
+      btn.click();
+      document.getElementById('search-close')!.click();
+      expect(focusSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('search execution', () => {
+    it('highlights matching messages', () => {
+      const msgs = [
+        makeMsg('1', 'Hello world'),
+        makeMsg('2', 'Goodbye world'),
+        makeMsg('3', 'Hello again'),
+      ];
+      setupSearchDOM(msgs);
+
+      document.getElementById('btn-search')!.click();
+      const input = document.getElementById('search-input') as HTMLInputElement;
+      input.value = 'Hello';
+      input.dispatchEvent(new Event('input'));
+
+      // Debounce timer
+      vi.advanceTimersByTime(200);
+
+      const matches = document.querySelectorAll('.msg--search-match');
+      expect(matches.length).toBe(2);
+      const count = document.getElementById('search-count')!;
+      expect(count.textContent).toContain('1 of 2');
+    });
+
+    it('shows "No matches" for unmatched query', () => {
+      setupSearchDOM([makeMsg('1', 'Hello')]);
+      document.getElementById('btn-search')!.click();
+      const input = document.getElementById('search-input') as HTMLInputElement;
+      input.value = 'zzzzz';
+      input.dispatchEvent(new Event('input'));
+      vi.advanceTimersByTime(200);
+
+      expect(document.getElementById('search-count')!.textContent).toBe('No matches');
+    });
+
+    it('shows empty count text when query is cleared', () => {
+      setupSearchDOM([makeMsg('1', 'Hello')]);
+      document.getElementById('btn-search')!.click();
+      const input = document.getElementById('search-input') as HTMLInputElement;
+      input.value = 'Hello';
+      input.dispatchEvent(new Event('input'));
+      vi.advanceTimersByTime(200);
+
+      input.value = '';
+      input.dispatchEvent(new Event('input'));
+      vi.advanceTimersByTime(200);
+
+      expect(document.getElementById('search-count')!.textContent).toBe('');
+    });
+
+    it('case-insensitive search', () => {
+      setupSearchDOM([makeMsg('1', 'Hello World')]);
+      document.getElementById('btn-search')!.click();
+      const input = document.getElementById('search-input') as HTMLInputElement;
+      input.value = 'hello';
+      input.dispatchEvent(new Event('input'));
+      vi.advanceTimersByTime(200);
+
+      expect(document.querySelectorAll('.msg--search-match').length).toBe(1);
+    });
+
+    it('escapes regex special characters in query', () => {
+      setupSearchDOM([makeMsg('1', 'price is $10.00')]);
+      document.getElementById('btn-search')!.click();
+      const input = document.getElementById('search-input') as HTMLInputElement;
+      input.value = '$10.00';
+      input.dispatchEvent(new Event('input'));
+      vi.advanceTimersByTime(200);
+
+      expect(document.querySelectorAll('.msg--search-match').length).toBe(1);
+    });
+
+    it('activates first match with msg--search-active class', () => {
+      setupSearchDOM([makeMsg('1', 'Hello'), makeMsg('2', 'Hello')]);
+      document.getElementById('btn-search')!.click();
+      const input = document.getElementById('search-input') as HTMLInputElement;
+      input.value = 'Hello';
+      input.dispatchEvent(new Event('input'));
+      vi.advanceTimersByTime(200);
+
+      const active = document.querySelectorAll('.msg--search-active');
+      expect(active.length).toBe(1);
+      expect(active[0]!.id).toBe('msg-1');
+    });
+
+    it('scrolls active match into view', () => {
+      setupSearchDOM([makeMsg('1', 'Hello')]);
+      document.getElementById('btn-search')!.click();
+      const input = document.getElementById('search-input') as HTMLInputElement;
+      input.value = 'Hello';
+      input.dispatchEvent(new Event('input'));
+      vi.advanceTimersByTime(200);
+
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    });
+
+    it('inserts highlight marks in matching text nodes', () => {
+      setupSearchDOM([makeMsg('1', 'Hello world')]);
+      document.getElementById('btn-search')!.click();
+      const input = document.getElementById('search-input') as HTMLInputElement;
+      input.value = 'world';
+      input.dispatchEvent(new Event('input'));
+      vi.advanceTimersByTime(200);
+
+      const marks = document.querySelectorAll('mark.search-highlight');
+      expect(marks.length).toBeGreaterThanOrEqual(1);
+      expect(marks[0]!.textContent).toBe('world');
+    });
+  });
+
+  describe('search navigation', () => {
+    function setupWithMatches() {
+      setupSearchDOM([
+        makeMsg('1', 'Match here'),
+        makeMsg('2', 'Match there'),
+        makeMsg('3', 'Match everywhere'),
+      ]);
+      document.getElementById('btn-search')!.click();
+      const input = document.getElementById('search-input') as HTMLInputElement;
+      input.value = 'Match';
+      input.dispatchEvent(new Event('input'));
+      vi.advanceTimersByTime(200);
+    }
+
+    it('navigates to next match on Next button click', () => {
+      setupWithMatches();
+      expect(document.querySelector('.msg--search-active')?.id).toBe('msg-1');
+
+      document.getElementById('search-next')!.click();
+      expect(document.querySelector('.msg--search-active')?.id).toBe('msg-2');
+    });
+
+    it('wraps around to first match after last', () => {
+      setupWithMatches();
+      document.getElementById('search-next')!.click(); // -> 2
+      document.getElementById('search-next')!.click(); // -> 3
+      document.getElementById('search-next')!.click(); // -> 1 (wrap)
+      expect(document.querySelector('.msg--search-active')?.id).toBe('msg-1');
+    });
+
+    it('navigates to previous match on Prev button click', () => {
+      setupWithMatches();
+      document.getElementById('search-next')!.click(); // -> 2
+      document.getElementById('search-prev')!.click(); // -> 1
+      expect(document.querySelector('.msg--search-active')?.id).toBe('msg-1');
+    });
+
+    it('wraps to last match when pressing Prev at first', () => {
+      setupWithMatches();
+      document.getElementById('search-prev')!.click(); // wrap -> 3
+      expect(document.querySelector('.msg--search-active')?.id).toBe('msg-3');
+    });
+
+    it('updates count display on navigation', () => {
+      setupWithMatches();
+      expect(document.getElementById('search-count')!.textContent).toBe('1 of 3 matches');
+      document.getElementById('search-next')!.click();
+      expect(document.getElementById('search-count')!.textContent).toBe('2 of 3 matches');
+    });
+
+    it('disables nav buttons when fewer than 2 matches', () => {
+      setupSearchDOM([makeMsg('1', 'Unique text')]);
+      document.getElementById('btn-search')!.click();
+      const input = document.getElementById('search-input') as HTMLInputElement;
+      input.value = 'Unique';
+      input.dispatchEvent(new Event('input'));
+      vi.advanceTimersByTime(200);
+
+      expect((document.getElementById('search-prev') as HTMLButtonElement).disabled).toBe(true);
+      expect((document.getElementById('search-next') as HTMLButtonElement).disabled).toBe(true);
+      expect(document.getElementById('search-count')!.textContent).toBe('1 of 1 match');
+    });
+  });
+
+  describe('keyboard shortcuts', () => {
+    it('closes search on Escape key', () => {
+      setupSearchDOM();
+      document.getElementById('btn-search')!.click();
+      expect(isSearchOpen()).toBe(true);
+
+      const input = document.getElementById('search-input')!;
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      expect(isSearchOpen()).toBe(false);
+    });
+
+    it('navigates to next match on Enter key', () => {
+      setupSearchDOM([makeMsg('1', 'Test'), makeMsg('2', 'Test')]);
+      document.getElementById('btn-search')!.click();
+      const input = document.getElementById('search-input') as HTMLInputElement;
+      input.value = 'Test';
+      input.dispatchEvent(new Event('input'));
+      vi.advanceTimersByTime(200);
+
+      expect(document.querySelector('.msg--search-active')?.id).toBe('msg-1');
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      expect(document.querySelector('.msg--search-active')?.id).toBe('msg-2');
+    });
+
+    it('navigates to previous match on Shift+Enter', () => {
+      setupSearchDOM([makeMsg('1', 'Test'), makeMsg('2', 'Test'), makeMsg('3', 'Test')]);
+      document.getElementById('btn-search')!.click();
+      const input = document.getElementById('search-input') as HTMLInputElement;
+      input.value = 'Test';
+      input.dispatchEvent(new Event('input'));
+      vi.advanceTimersByTime(200);
+
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', shiftKey: true, bubbles: true }));
+      expect(document.querySelector('.msg--search-active')?.id).toBe('msg-3');
+    });
+  });
+
+  describe('clearSearchHighlights', () => {
+    it('removes highlight marks and classes on close', () => {
+      setupSearchDOM([makeMsg('1', 'Hello world')]);
+      document.getElementById('btn-search')!.click();
+      const input = document.getElementById('search-input') as HTMLInputElement;
+      input.value = 'Hello';
+      input.dispatchEvent(new Event('input'));
+      vi.advanceTimersByTime(200);
+
+      expect(document.querySelectorAll('.msg--search-match').length).toBe(1);
+      expect(document.querySelectorAll('mark.search-highlight').length).toBeGreaterThan(0);
+
+      document.getElementById('search-close')!.click();
+
+      expect(document.querySelectorAll('.msg--search-match').length).toBe(0);
+      expect(document.querySelectorAll('mark.search-highlight').length).toBe(0);
+    });
+  });
+
+  describe('resetSearchState', () => {
+    it('clears all module state', () => {
+      setupSearchDOM();
+      document.getElementById('btn-search')!.click();
+      expect(isSearchOpen()).toBe(true);
+      resetSearchState();
+      expect(isSearchOpen()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 69 new unit tests covering three previously untested modules: `toast.ts`, `chat-messages.ts`, and `chat-search.ts`
- Fix `toast.ts` container singleton to check `isConnected`, preventing stale DOM references
- Total test count: 370 → 439

## Test plan
- [x] TSC clean (`bunx tsc --noEmit`)
- [x] All 439 tests pass (`bun run test`)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)